### PR TITLE
77 URL Popup tracking & Side Sync Bugfixes

### DIFF
--- a/src/100-App/AppContent.tsx
+++ b/src/100-App/AppContent.tsx
@@ -62,9 +62,9 @@ const AppContent = () => {
     const MENU_CONFIG_LIST:MenuPageListing[] = [
       {label: 'Profile', route: `/portal/edit/profile/${userID}`, activeIcon: PROFILE_ICON_ACTIVE, inactiveIcon: PROFILE_ICON},
       {label: 'Circle', route: '/portal/edit/circle/-1', activeIcon: CIRCLE_ICON_ACTIVE, inactiveIcon: CIRCLE_ICON, addRoute: '/portal/edit/circle/new', exclusiveRoleList: [RoleEnum.CIRCLE_LEADER, RoleEnum.ADMIN]},
-      {label: 'Prayer Request', route: '/portal/edit/prayer-request/-1', activeIcon: PRAYER_REQUEST_ICON_ACTIVE, inactiveIcon: PRAYER_REQUEST_ICON, addRoute: '/portal/edit/prayer-request/new'},
-      {label: 'Messages', route: '/portal/chat/direct', activeIcon: DIRECT_CHAT_ICON_ACTIVE, inactiveIcon: DIRECT_CHAT_ICON},
-      {label: 'Circle Chat', route: '/portal/chat/circle', activeIcon: CIRCLE_CHAT_ICON_ACTIVE, inactiveIcon: CIRCLE_CHAT_ICON},
+      {label: 'Prayer Request', route: '/portal/edit/prayer-request/-1', activeIcon: PRAYER_REQUEST_ICON_ACTIVE, inactiveIcon: PRAYER_REQUEST_ICON, addRoute: '/portal/edit/prayer-request/new', exclusiveRoleList: [RoleEnum.STUDENT, RoleEnum.ADMIN]},
+      {label: 'Messages', route: '/portal/chat/direct', activeIcon: DIRECT_CHAT_ICON_ACTIVE, inactiveIcon: DIRECT_CHAT_ICON, exclusiveRoleList: [RoleEnum.ADMIN]},
+      {label: 'Circle Chat', route: '/portal/chat/circle', activeIcon: CIRCLE_CHAT_ICON_ACTIVE, inactiveIcon: CIRCLE_CHAT_ICON, exclusiveRoleList: [RoleEnum.ADMIN]},
       {label: 'Logs', route: '/portal/logs', activeIcon: LOG_ICON_ACTIVE, inactiveIcon: LOG_ICON, exclusiveRoleList: [RoleEnum.ADMIN]},
     ];
 
@@ -142,8 +142,11 @@ const AppContent = () => {
                 <Routes>
                   <Route path='/portal' element={ <Navigate to='/portal/dashboard' /> }/>
                   <Route path='/portal/dashboard/*' element={<Dashboard/>}/>
+                  <Route path='/portal/edit/profile/:id/:action' element={<UserEditPage/>}/>
                   <Route path='/portal/edit/profile/:id/*' element={<UserEditPage/>}/>
+                  <Route path='/portal/edit/circle/:id/:action' element={<CircleEditPage/>}/>
                   <Route path='/portal/edit/circle/:id/*' element={<CircleEditPage/>}/>
+                  <Route path='/portal/edit/prayer-request/:id/:action' element={<PrayerRequestEditPage/>}/>
                   <Route path='/portal/edit/prayer-request/:id/*' element={<PrayerRequestEditPage/>}/>
                   <Route path='/portal/chat/direct/*' element={<DirectChat/>}/>
                   <Route path='/portal/chat/circle/*' element={<CircleChat/>}/>

--- a/src/11-Models/Login.tsx
+++ b/src/11-Models/Login.tsx
@@ -20,29 +20,6 @@ const Login = () => {
     const dispatch = useAppDispatch();
     const [inputMap, setInputMap] = useState<Map<string, string>>(new Map());
 
-    
-    /*******************************************
-     *          Dynamic Curvy Background
-     * *****************************************/
-    const popupWrapperRef = useRef<null | HTMLDivElement>(null);
-    const [shapeTop, setShapeTop] = useState<number>(0);
-    const [shapeHeight, setShapeHeight] = useState<number>(0);
-
-    // useEffect(() => {
-    //     setTimeout(()=> {
-    //     if (popupWrapperRef.current) {
-    //         let top = missionRef.current.offsetTop + missionRef.current.offsetHeight + 40;
-    //         let height = topHeaderRef.current.offsetHeight - top + 50;
-            
-    //         if(demoRef.current.offsetTop > missionRef.current.offsetTop) {
-    //             top = demoRef.current.offsetTop + demoRef.current.offsetHeight - 20;
-    //             height = 50;
-    //         }
-
-    //         setShapeTop(top);
-    //         setShapeHeight(height);
-    //     }}, 300);
-    // }, [topHeaderRef.current, missionRef.current, demoRef.current]);
 
     /************************************************** //TODO Remove for Production
      *  [TEMPORARY] Credentials fetched for Debugging
@@ -102,7 +79,7 @@ const Login = () => {
      * *******************/
     return (
         <div id='login-page' className='center-absolute-wrapper'>
-            <div ref={popupWrapperRef} id='popup-wrapper' className='form-page-block center-absolute-inside' >
+            <div id='popup-wrapper' className='form-page-block center-absolute-inside' >
                 <div id='logo-box' >
                     <img src={LOGO} alt='log-title'/>
                     <h1>Encouraging Prayer</h1>
@@ -136,9 +113,9 @@ const Login = () => {
                 
             </div>
 
-            <div id='shape-rectangle' style={{  }}></div>
-
-            <div style={{ }} id='shape-curve'>
+            {/* Swoop Background */}
+            <div id='shape-rectangle'></div>
+            <div id='shape-curve'>
                 <svg viewBox='0 0 500 150' preserveAspectRatio='none'>
                     <path d='M-2.49,14.31 C274.02,-18.24 292.64,224.51 507.09,115.96 L500.00,0.00 L0.00,0.00 Z'></path>
                 </svg>

--- a/src/11-Models/UserEditPage.tsx
+++ b/src/11-Models/UserEditPage.tsx
@@ -8,7 +8,7 @@ import InputField, { makeDisplayList } from '../0-Assets/field-sync/input-config
 import { EDIT_PROFILE_FIELDS, EDIT_PROFILE_FIELDS_ADMIN, RoleEnum } from '../0-Assets/field-sync/input-config-sync/profile-field-config';
 import { notify, processAJAXError, useAppDispatch, useAppSelector } from '../1-Utilities/hooks';
 import { ToastStyle } from '../100-App/app-types';
-import { removeCircle, removePrayerRequest, resetAccount, updateProfile, updateProfileImage } from '../100-App/redux-store';
+import { removeCircle, removePrayerRequest, resetAccount, updateProfile } from '../100-App/redux-store';
 import FormInput from '../2-Widgets/Form/FormInput';
 import SearchList from '../2-Widgets/SearchList/SearchList';
 import { DisplayItemType, ListItemTypesEnum, SearchListKey, SearchListSearchTypesEnum, SearchListValue } from '../2-Widgets/SearchList/searchList-types';

--- a/src/11-Models/UserEditPage.tsx
+++ b/src/11-Models/UserEditPage.tsx
@@ -8,7 +8,7 @@ import InputField, { makeDisplayList } from '../0-Assets/field-sync/input-config
 import { EDIT_PROFILE_FIELDS, EDIT_PROFILE_FIELDS_ADMIN, RoleEnum } from '../0-Assets/field-sync/input-config-sync/profile-field-config';
 import { notify, processAJAXError, useAppDispatch, useAppSelector } from '../1-Utilities/hooks';
 import { ToastStyle } from '../100-App/app-types';
-import { removeCircle, removePrayerRequest, resetAccount, updateProfile } from '../100-App/redux-store';
+import { removeCircle, removePrayerRequest, resetAccount, updateProfile, updateProfileImage } from '../100-App/redux-store';
 import FormInput from '../2-Widgets/Form/FormInput';
 import SearchList from '../2-Widgets/SearchList/SearchList';
 import { DisplayItemType, ListItemTypesEnum, SearchListKey, SearchListSearchTypesEnum, SearchListValue } from '../2-Widgets/SearchList/searchList-types';
@@ -25,7 +25,7 @@ const UserEditPage = () => {
     const userID:number = useAppSelector((state) => state.account.userID);
     const userRole:string = useAppSelector((state) => state.account.userProfile.userRole);
     const userAccessProfileList:ProfileListItem[] = useAppSelector((state) => state.account.userProfile.profileAccessList) || [];
-    const { id = -1 } = useParams();
+    const { id = -1, action } = useParams();
 
     const [EDIT_FIELDS, setEDIT_FIELDS] = useState<InputField[]>([]);
     const [inputMap, setInputMap] = useState<Map<string, any>>(new Map());
@@ -42,7 +42,21 @@ const UserEditPage = () => {
 
 
     //Triggers | (delays fetchProfile until after Redux auto login)
-    useLayoutEffect(() => { if(id as number > 0) setEditingUserID(parseInt(id.toString()));}, [id]);
+    useLayoutEffect(() => { 
+        if(id as number > 0) 
+            setEditingUserID(parseInt(id.toString()));
+    }, [id]);
+
+
+    /* Sync state change to URL action */
+    useEffect(() => {
+        if(showDeleteConfirmation) 
+            navigate(`/portal/edit/profile/${editingUserID}/delete`);
+        else 
+            navigate(`/portal/edit/profile/${editingUserID}`);
+
+    }, [showDeleteConfirmation]);
+
 
     //componentDidMount
     useLayoutEffect(() => {
@@ -58,7 +72,7 @@ const UserEditPage = () => {
      *     RETRIEVE PROFILE BEING EDITED
      * *****************************************/
     useLayoutEffect (() => { 
-        navigate(`/portal/edit/profile/${editingUserID}`); //Should not re-render: https://stackoverflow.com/questions/56053810/url-change-without-re-rendering-in-react-router
+        navigate(`/portal/edit/profile/${editingUserID}/${action || ''}`); //Should not re-render: https://stackoverflow.com/questions/56053810/url-change-without-re-rendering-in-react-router
         if(editingUserID > 0 && userID > 0) fetchProfile(editingUserID); }, [userID, editingUserID]);
 
 
@@ -67,21 +81,27 @@ const UserEditPage = () => {
         .then(response => {
             const fields:ProfileResponse = response.data;
             const valueMap:Map<string, any> = new Map([['userID', fields.userID as unknown as string], ['userRole', fields.userRole]]);
+            //Clear Lists, not returned if empty
+            setPartnerProfileList([]);
+            setMemberCircleList([]);
+            setPrayerRequestList([]);
+            setImage(undefined);
 
             [...Object.entries(fields)].forEach(([field, value]) => {
                 if(field === 'userRoleList' && EDIT_FIELDS.some(f => f.field === 'userRoleTokenList')) {
                     valueMap.set('userRoleTokenList', new Map(Array.from(value).map((role) => ([role, '']))));
                 } else if(field === 'partnerList') {
-                    setPartnerProfileList(value);
+                    setPartnerProfileList([...value]);
 
                 } else if(field === 'circleList') {
-                    setMemberCircleList(value);
+                    setMemberCircleList([...value]);
 
                 } else if(field === 'prayerRequestList') {
-                    setPrayerRequestList(value);
+                    setPrayerRequestList([...value]);
 
                 } else if(field === 'image') {
                     setImage(value);
+                    valueMap.set('image', value);
 
                 } else if(EDIT_FIELDS.some(f => f.field === field))
                     valueMap.set(field, value);
@@ -89,6 +109,10 @@ const UserEditPage = () => {
                     console.log(`EditProfile-skipping field: ${field}`, value);
             });
             setInputMap(new Map(valueMap));
+
+            /* Update State based on sub route */
+            if(action === 'delete') 
+                setShowDeleteConfirmation(true);
         })
         .catch((error) => processAJAXError(error, () => setEditingUserID(userID)));
 
@@ -239,7 +263,7 @@ const UserEditPage = () => {
             {(showDeleteConfirmation) &&
                 <div key={'UserEdit-confirmDelete-'+editingUserID} id='confirm-delete' className='center-absolute-wrapper' onClick={()=>setShowDeleteConfirmation(false)}>
 
-                    <div className='form-page-block center-absolute-inside'>
+                    <div className='form-page-block center-absolute-inside' onClick={(e)=>e.stopPropagation()} >
                         <div className='form-header-detail-box'>
                             <h1 className='name'>{getInputField('firstName')} {getInputField('lastName')}</h1>
                             <span>

--- a/src/11-Models/UserSignUpPage.tsx
+++ b/src/11-Models/UserSignUpPage.tsx
@@ -43,11 +43,8 @@ const SignUpPage = () => {
         //Assemble Request Body (Simple JavaScript Object)
         const requestBody:ProfileEditRequestBody = {} as ProfileEditRequestBody;
         finalMap.forEach((value, field) => {
-            if(field === 'userRoleTokenList') { //@ts-ignore
-                requestBody[field] = Array.from((finalMap.get('userRoleTokenList') as Map<string,string>).entries())
-                                        .map(([role, token]) => ({role: role, token: token || ''}));
-            } else //@ts-ignore
-                requestBody[field] = value;
+            //@ts-ignore
+            requestBody[field] = value;
         });
 
         await axios.post(`${process.env.REACT_APP_DOMAIN}/signup`, requestBody)
@@ -63,7 +60,7 @@ const SignUpPage = () => {
                 window.localStorage.setItem('user', JSON.stringify(account));
 
                 notify(`Welcome ${account.userProfile.firstName}`, ToastStyle.SUCCESS);
-                navigate('/portal/dashboard');
+                navigate(`/portal/edit/profile/${response.data.userID}/image`);
 
             }).catch((error) => { processAJAXError(error); });
     }
@@ -77,7 +74,7 @@ const SignUpPage = () => {
     return (
         <div id='sign-up-page' className='center-absolute-wrapper' >
 
-            <div className='form-page-block center-absolute-inside'>
+            <div id='popup-wrapper' className='form-page-block center-absolute-inside'>
                 <div id='logo-box' >
                     <img src={LOGO} alt='log-title'/>
                     <h1>Encouraging Prayer</h1>
@@ -94,6 +91,14 @@ const SignUpPage = () => {
                     onAlternativeText='Already have an account?'
                     onAlternativeCallback={()=>navigate('/login')}
                 />
+            </div>
+
+            {/* Swoop Background */}
+            <div id='shape-rectangle'></div>
+            <div id='shape-curve'>
+                <svg viewBox='0 0 500 150' preserveAspectRatio='none'>
+                    <path d='M-2.49,14.31 C274.02,-18.24 292.64,224.51 507.09,115.96 L500.00,0.00 L0.00,0.00 Z'></path>
+                </svg>
             </div>
         </div>
     );

--- a/src/11-Models/UserSignUpPage.tsx
+++ b/src/11-Models/UserSignUpPage.tsx
@@ -60,7 +60,7 @@ const SignUpPage = () => {
                 window.localStorage.setItem('user', JSON.stringify(account));
 
                 notify(`Welcome ${account.userProfile.firstName}`, ToastStyle.SUCCESS);
-                navigate(`/portal/edit/profile/${response.data.userID}/image`);
+                navigate('/portal/dashboard');
 
             }).catch((error) => { processAJAXError(error); });
     }

--- a/src/2-Widgets/Form/form.scss
+++ b/src/2-Widgets/Form/form.scss
@@ -59,7 +59,7 @@
         flex-direction: row;
         justify-content: center;
         max-width: fit-content;
-        margin: auto;
+        margin: 1.0rem auto 0.5rem auto;
     }
 
     .form-header-button {
@@ -203,6 +203,21 @@
 .submit-button {
     grid-column: 1 /span 2;
     width: 15rem;
+    margin: 0.5rem auto;
+}
+
+.secondary-button {
+    grid-column: 1 /span 2;
+    color: $blue;
+    background-color: white;
+    border: 1px solid $blue;
+    white-space: nowrap;
+
+    &:hover {
+        color: white;
+        background-color: $blue;
+        border: 1px solid transparent;
+    }
 }
 
 .alternative-button {
@@ -252,7 +267,7 @@
 }
 
 // Dividers
-.id-left, .id-right {
+.id, .detail {
     color: darkgray;
     font-size: 0.9em;
     font-weight: 400;
@@ -261,12 +276,14 @@
 }
 
 .id-left {
+    @extend .id;
     margin-left: 0.5rem;
     padding-left: 0.5rem;
     border-left: 1px solid darkgray;
 }
 
 .id-right {
+    @extend .id;
     margin-right: 0.5rem;
     padding-right: 0.5rem;
     border-right: 1px solid darkgray;
@@ -297,7 +314,8 @@
 }
 
 
-#confirm-delete {
+#confirm-delete,
+#image-upload {
 
     .center-absolute-inside {
         display: flex;
@@ -308,6 +326,40 @@
             max-width: min(50vw, 700px);
             max-height: 30vh;
             margin: 1.0rem auto;
-        }        
+        }  
+    }
+}
+
+#image-upload {
+    .image-upload-drag-area {
+        height: 40vh;
+        margin: 1.0rem 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        border: 2px dashed $blue;
+        border-radius: 1rem;
+    }      
+
+    .image-upload-drag-area.drag-active {
+        background-color: $blue;
+
+        button {
+            background-color: white;
+            color: $blue;
+        }
+    }
+
+    /* Cover Full View Port */
+    .image-upload-drag-active {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        border-radius: $radius;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
     }
 }

--- a/src/2-Widgets/SearchList/searchList-types.tsx
+++ b/src/2-Widgets/SearchList/searchList-types.tsx
@@ -52,7 +52,7 @@ export class SearchListKey {
     constructor({...props}:{displayTitle:string, searchType?:SearchListSearchTypesEnum, searchCircleStatus?:CircleStatusEnum, onSearchClick?:(id:number, item:DisplayItemType)=>void, 
         searchPrimaryButtonText?:string, onSearchPrimaryButtonCallback?:(id:number, item:DisplayItemType)=>void, searchAlternativeButtonText?:string, onSearchAlternativeButtonCallback?:(id:number, item:DisplayItemType)=>void}) {
         this.displayTitle = props.displayTitle;
-        this.searchType = props.searchType;
+        this.searchType = props.searchType || undefined;
         this.searchCircleStatus = props.searchCircleStatus;
         this.onSearchClick = props.onSearchClick;
         this.searchPrimaryButtonText = props.searchPrimaryButtonText;


### PR DESCRIPTION
1. **Support URL Sub routes, which immediately opens popup on page load from URL**
   1. This will be helpful with support and sharing links
   2. Supports Syncing State (popup open) to update URL
   3. Supports Syncing URL to state (popup open)
   
2. **Supported Sub Routes:**
`http://localhost:3000/portal/edit/profile/1/delete`
   1. User Edit:
      1. `/image` upload profile image
      2. `/delete` delete profile
   2. Circle Edit
      1. `/announcement` post announcement
      2. `/image` upload circle image
      3. `/delete` delete circle
   3. Prayer Request Edit
      1. `/comment` post comment
      2. `/delete` delete prayer request
      
3. **Prayer Request Edit Side Panel**
   1. Fix Syncing Issues switching between prayer request and comments
   2. Fix key mapping to show search bar only when relevant
   5. Properly sync Dropdown menu and labeling
   6. Ability to search and browse prayer requests without changing/selecting main content
