### PR TITLE
95 mobile content

### DIFF
--- a/src/0-Assets/field-sync/api-type-sync/content-types.ts
+++ b/src/0-Assets/field-sync/api-type-sync/content-types.ts
@@ -1,6 +1,6 @@
 /*********** ONLY DEPENDENCIES FROM DIRECTORY: /field-sync/ ***********/
 
-import { GenderSelectionEnum } from '../input-config-sync/content-field-config';
+import { ContentSourceEnum, ContentTypeEnum, GenderSelectionEnum } from '../input-config-sync/content-field-config';
 import { ProfileListItem } from './profile-types';
 
 
@@ -14,11 +14,14 @@ import { ProfileListItem } from './profile-types';
 
 export interface ContentListItem {
     contentID: number,
-    type: string,
-    source: string,
+    type: ContentTypeEnum,
+    source: ContentSourceEnum,
     url: string,
     keywordList: string[],
+    title?: string,
     description?: string, 
+    image?: string,
+    likeCount: number,
 }
 
 
@@ -26,11 +29,14 @@ export interface ContentResponseBody {
     contentID: number,
     recorderID: number,
     recorderProfile: ProfileListItem, 
-    type: string,
-    source: string,
+    type: ContentTypeEnum,
+    source: ContentSourceEnum,
     url: string,
     keywordList: string,
-    description?: string, 
+    title?: string,
+    description?: string,
+    image?: string,
+    likeCount: number,
     gender: GenderSelectionEnum,
     minimumAge: number,
     maximumAge: number,
@@ -39,3 +45,14 @@ export interface ContentResponseBody {
     notes?: string
 }
 
+export interface ContentMetaDataRequestBody {
+    url:string,
+    type: ContentTypeEnum
+    source: ContentSourceEnum
+}
+
+export type ContentMetaDataResponseBody = {
+    title:string|undefined,
+    description:string|undefined,
+    imageURL:string|undefined,
+}

--- a/src/0-Assets/field-sync/input-config-sync/content-field-config.ts
+++ b/src/0-Assets/field-sync/input-config-sync/content-field-config.ts
@@ -11,26 +11,40 @@ import InputField, { InputRangeField, InputSelectionField, InputType } from './i
 ****************************************/
 //Note: enums must have matching values to cast (string as Enum) or define (Enum[string]) equally
 
-
 export enum ContentTypeEnum {
-    POST = 'POST',
-    ARTICLE = 'ARTICLE',
     VIDEO = 'VIDEO',
+    ARTICLE = 'ARTICLE',
     IMAGE = 'IMAGE',
+    POST = 'POST',
     CUSTOM = 'CUSTOM'
 }
 
 export enum ContentSourceEnum {
     YOUTUBE = 'YOUTUBE',
+    GOT_QUESTIONS = 'GOT_QUESTIONS',
+    BIBLE_PROJECT = 'BIBLE_PROJECT',
+    THROUGH_THE_WORD = 'THROUGH_THE_WORD',
     FACEBOOK = 'FACEBOOK',
     INSTAGRAM = 'INSTAGRAM',
     PINTEREST = 'PINTEREST',
     TIKTOK = 'TIKTOK',
     X_TWITTER = 'X_TWITTER',
-    GOT_QUESTIONS = 'GOT_QUESTIONS',
-    BIBLE_PROJECT = 'BIBLE_PROJECT',
-    THROUGH_THE_WORLD = 'THROUGH_THE_WORLD',
     CUSTOM = 'CUSTOM'
+}
+
+export const MOBILE_CONTENT_REQUIRE_THUMBNAIL:boolean = true;
+export const MOBILE_CONTENT_SUPPORTED_SOURCES:ContentSourceEnum[] = [
+    ContentSourceEnum.YOUTUBE, 
+    ContentSourceEnum.GOT_QUESTIONS, 
+    ContentSourceEnum.BIBLE_PROJECT,
+    ContentSourceEnum.THROUGH_THE_WORD
+];
+
+//TS can't extend enum, but object operates similar
+export const ContentSearchFilterEnum = {
+    ...ContentSourceEnum,
+    NONE: 'NONE',
+    MOBILE: 'MOBILE',
 }
 
 export enum GenderSelectionEnum {
@@ -50,6 +64,14 @@ export enum ContentSearchRefineEnum {
     NOTES = 'NOTES'
 }
 
+/******************
+* UTILITY METHODS *
+*******************/
+export const extractYouTubeVideoId = (url:string):string|undefined => {
+    const match = url.match(/(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+    return match ? match[1] : undefined;
+  };
+
 /*********************************************************************************
 *   FIELD LISTS: CREATE | EDIT =>  Used for dynamic display 
 **********************************************************************************/
@@ -58,11 +80,14 @@ export const EDIT_CONTENT_FIELDS:InputField[] = [
     new InputField({title: 'Embed URL', field: 'url', type: InputType.TEXT, required: true, unique: true, validationRegex: new RegExp(/^.{1,2000}$/), validationMessage: 'Required, max 2000 characters.' }),
     new InputSelectionField({title: 'Type', field: 'type', customField: 'customType', type: InputType.SELECT_LIST, required: true, selectOptionList: Object.values(ContentTypeEnum), validationRegex: new RegExp(/^[a-zA-Z0-9_ ]{3,50}$/), validationMessage: 'Custom Field has invalid format.'}),
     new InputSelectionField({title: 'Source', field: 'source', customField: 'customSource', type: InputType.SELECT_LIST, required: true, selectOptionList: Object.values(ContentSourceEnum), validationRegex: new RegExp(/^[a-zA-Z0-9_ ]{3,50}$/), validationMessage: 'Custom Field has invalid format.'}),
+    new InputField({title: 'Thumbnail URL', field: 'image', type: InputType.TEXT, validationRegex: new RegExp(/^.{1,2000}$/), validationMessage: 'Required, max 2000 characters.' }),
+    new InputField({title: 'Title', field: 'title', type: InputType.TEXT, validationRegex: new RegExp(/^.{1,50}$/), validationMessage: 'Required, max 50 characters.' }),
+    new InputField({title: 'Description', field: 'description',  type: InputType.PARAGRAPH, validationRegex: new RegExp(/^.{0,200}$/), validationMessage: 'Max 300 characters.'}),
     new InputField({title: 'Topic / Keywords', field: 'keywordList', type: InputType.CUSTOM_STRING_LIST, validationRegex: new RegExp(/^.{1,3}$/), validationMessage: 'Invalid, Min 3 characters.'}),
     new InputSelectionField({title: 'Gender', field: 'gender', type: InputType.SELECT_LIST, required: true, selectOptionList: Object.values(GenderSelectionEnum)}),
     new InputRangeField({title: 'Age', field: 'minimumAge', maxField: 'maximumAge', minValue: 13, maxValue: 21, type: InputType.RANGE_SLIDER, required: true, validationRegex: new RegExp(/[0-9]+/), validationMessage: 'Required, age between 13-21.'}),
     new InputRangeField({title: 'Walk Level', field: 'minimumWalkLevel', maxField: 'maximumWalkLevel', minValue: 1, maxValue: 10, type: InputType.RANGE_SLIDER, required: true, validationRegex: new RegExp(/[0-9]+/), validationMessage: 'Required, age between 1-10 and less than Maximum Walk Level.'}),
-    new InputField({title: 'Description', field: 'description',  type: InputType.PARAGRAPH, validationRegex: new RegExp(/^.{0,200}$/), validationMessage: 'Max 300 characters.'})
+    new InputField({title: 'Like Count', field: 'likeCount', type: InputType.NUMBER, validationRegex: new RegExp(/^[0-9]+$/)})
 ];
 
 export const EDIT_CONTENT_FIELDS_ADMIN:InputField[] = [    
@@ -70,4 +95,3 @@ export const EDIT_CONTENT_FIELDS_ADMIN:InputField[] = [
     new InputField({title: 'Recorder ID', field: 'recorderID', type: InputType.NUMBER, validationMessage: 'User is Required.' }),
     new InputField({title: 'Notes', field: 'notes', type: InputType.PARAGRAPH, validationRegex: new RegExp(/^.{0,3000}$/), validationMessage: 'Max 3000 characters.'}),
 ];
-

--- a/src/0-Assets/field-sync/input-config-sync/content-field-config.ts
+++ b/src/0-Assets/field-sync/input-config-sync/content-field-config.ts
@@ -1,5 +1,5 @@
 /***** ONLY DEPENDENCY: ./inputField - Define all other types locally *****/
-import InputField, { InputRangeField, InputSelectionField, InputType } from './inputField';
+import InputField, { InputRangeField, InputSelectionField, InputType, makeDisplayText } from './inputField';
 
 /*******************************************************
 *      CONTENT ARCHIVE FIELD CONFIGURATION FILE
@@ -78,10 +78,10 @@ export const extractYouTubeVideoId = (url:string):string|undefined => {
 
 export const EDIT_CONTENT_FIELDS:InputField[] = [
     new InputField({title: 'Embed URL', field: 'url', type: InputType.TEXT, required: true, unique: true, validationRegex: new RegExp(/^.{1,2000}$/), validationMessage: 'Required, max 2000 characters.' }),
-    new InputSelectionField({title: 'Type', field: 'type', customField: 'customType', type: InputType.SELECT_LIST, required: true, selectOptionList: Object.values(ContentTypeEnum), validationRegex: new RegExp(/^[a-zA-Z0-9_ ]{3,50}$/), validationMessage: 'Custom Field has invalid format.'}),
     new InputSelectionField({title: 'Source', field: 'source', customField: 'customSource', type: InputType.SELECT_LIST, required: true, selectOptionList: Object.values(ContentSourceEnum), validationRegex: new RegExp(/^[a-zA-Z0-9_ ]{3,50}$/), validationMessage: 'Custom Field has invalid format.'}),
+    new InputSelectionField({title: 'Type', field: 'type', customField: 'customType', type: InputType.SELECT_LIST, required: true, selectOptionList: Object.values(ContentTypeEnum), validationRegex: new RegExp(/^[a-zA-Z0-9_ ]{3,50}$/), validationMessage: 'Custom Field has invalid format.'}),
     new InputField({title: 'Thumbnail URL', field: 'image', type: InputType.TEXT, validationRegex: new RegExp(/^.{1,2000}$/), validationMessage: 'Required, max 2000 characters.' }),
-    new InputField({title: 'Title', field: 'title', type: InputType.TEXT, validationRegex: new RegExp(/^.{1,50}$/), validationMessage: 'Required, max 50 characters.' }),
+    new InputField({title: 'Title', field: 'title', type: InputType.TEXT, required: true, validationRegex: new RegExp(/^.{1,50}$/), validationMessage: 'Required, max 50 characters.' }),
     new InputField({title: 'Description', field: 'description',  type: InputType.PARAGRAPH, validationRegex: new RegExp(/^.{0,200}$/), validationMessage: 'Max 300 characters.'}),
     new InputField({title: 'Topic / Keywords', field: 'keywordList', type: InputType.CUSTOM_STRING_LIST, validationRegex: new RegExp(/^.{1,3}$/), validationMessage: 'Invalid, Min 3 characters.'}),
     new InputSelectionField({title: 'Gender', field: 'gender', type: InputType.SELECT_LIST, required: true, selectOptionList: Object.values(GenderSelectionEnum)}),
@@ -89,6 +89,13 @@ export const EDIT_CONTENT_FIELDS:InputField[] = [
     new InputRangeField({title: 'Walk Level', field: 'minimumWalkLevel', maxField: 'maximumWalkLevel', minValue: 1, maxValue: 10, type: InputType.RANGE_SLIDER, required: true, validationRegex: new RegExp(/[0-9]+/), validationMessage: 'Required, age between 1-10 and less than Maximum Walk Level.'}),
     new InputField({title: 'Like Count', field: 'likeCount', type: InputType.NUMBER, validationRegex: new RegExp(/^[0-9]+$/)})
 ];
+
+//Indicate Mobile Supported Sources | Assumes selectOptionList and displayOptionList indexes are synced
+const sourceField:InputSelectionField = EDIT_CONTENT_FIELDS.find((field:InputField) => field.field === 'source') as InputSelectionField;
+sourceField.selectOptionList.forEach((source:string, index:number) => {
+    if(MOBILE_CONTENT_SUPPORTED_SOURCES.includes(ContentSourceEnum[source as keyof typeof ContentSourceEnum]))
+        sourceField.displayOptionList[index] = `${makeDisplayText(source)} (mobile)`;
+});
 
 export const EDIT_CONTENT_FIELDS_ADMIN:InputField[] = [    
     ...EDIT_CONTENT_FIELDS,

--- a/src/0-Assets/field-sync/input-config-sync/inputField.ts
+++ b/src/0-Assets/field-sync/input-config-sync/inputField.ts
@@ -125,7 +125,8 @@ export class InputRangeField extends InputField {
  *************/
 
 //Converts underscores to spaces and capitalizes each word
-export const makeDisplayList = (list:string[]):string[] => list.map(value => value.toLowerCase().split('_'||' ').map((s) => s.charAt(0).toUpperCase() + s.substring(1)).join(' '));
+export const makeDisplayText = (text:string = ''):string => text.toLowerCase().split('_'||' ').map((s) => s.charAt(0).toUpperCase() + s.substring(1)).join(' ');
+export const makeDisplayList = (list:string[]):string[] => list.map(value => makeDisplayText(value));
 
 //For parsing JSON Response vs FIELD_LIST and optional field properties
 export const checkFieldName = (FIELD_LIST:InputField[], fieldName:string, required?:boolean, unique?:boolean, hide?:boolean):boolean =>

--- a/src/11-Models/contentArchive.scss
+++ b/src/11-Models/contentArchive.scss
@@ -16,7 +16,7 @@
             max-width: 400px;
             margin: auto;
 
-            .content-image {
+            .content-image, .thumbnail-image {
                 object-fit: contain;
                 height: 100%;
                 width: 100%;
@@ -32,10 +32,6 @@
                 pointer-events: none;
             }
         }
-    }
-
-    .update-button {
-        margin-top: 0;
     }
 }
 

--- a/src/2-Widgets/Form/form.scss
+++ b/src/2-Widgets/Form/form.scss
@@ -271,7 +271,7 @@
     }    
 }
 
-.circle-image, .profile-image {
+.circle-image, .profile-image, .thumbnail-image {
     max-height: 25vh;
     box-shadow: calc(2 * $radius) calc(2 * $radius) calc(2 * $radius) calc(2 * $radius) rgba(0, 0, 0, 0.3);
   }

--- a/src/2-Widgets/ImageWidgets.tsx
+++ b/src/2-Widgets/ImageWidgets.tsx
@@ -6,12 +6,14 @@ import { useAppSelector } from '../1-Utilities/hooks';
 import LOGO from '../0-Assets/brand/logo.png';
 import PROFILE_DEFAULT from '../0-Assets/default-images/profile-default.png';
 import CIRCLE_DEFAULT from '../0-Assets/default-images/circle-default.png';
+import MEDIA_DEFAULT from '../0-Assets/default-images/media-blue.png';
 import NOT_FOUND from '../0-Assets/icons/404-icon-black.png';
 
 export enum ImageDefaultEnum {
     LOGO = 'LOGO',
     PROFILE = 'PROFILE',
     CIRCLE = 'CIRCLE',
+    MEDIA = 'MEDIA',
     NOT_FOUND = 'NOT_FOUND'
 }
 
@@ -23,6 +25,8 @@ export const getDefaultImage = (type?:ImageDefaultEnum):string|undefined => {
             return PROFILE_DEFAULT;
         case ImageDefaultEnum.CIRCLE:
             return CIRCLE_DEFAULT;
+        case ImageDefaultEnum.MEDIA:
+            return MEDIA_DEFAULT;
         default:
             return NOT_FOUND;
     }
@@ -86,6 +90,22 @@ export const CircleImage = (props:{src?:string, defaultSrc?:string, className?:s
     const handleError = () => setCurrentSource(defaultCircle);
   
     return ( <img className={`circle-image ${props.className || ''}`} style={props.style} src={currentSource} onError={handleError} alt='Circle Image' />);
+  };
+
+
+/***********************************************************
+ * Content Thumbnail Image Render | Handles Defaults                  *
+ * src can be either: URL, Base64, imported (not raw path) *
+ ***********************************************************/
+export const ContentThumbnailImage = (props:{src?:string, defaultSrc:string, className?:string, style?:React.CSSProperties}):JSX.Element => {
+    const defaultThumbnail = props.defaultSrc;
+    const [currentSource, setCurrentSource] = useState<string|undefined>(props.src || defaultThumbnail);
+
+    useEffect(() => setCurrentSource(props.src || defaultThumbnail), [props.src]);
+
+    const handleError = () => setCurrentSource(defaultThumbnail);
+  
+    return ( <img className={`thumbnail-image ${props.className || ''}`} style={props.style} src={currentSource} onError={handleError} alt='Thumbnail Image' />);
   };
 
 

--- a/src/2-Widgets/SearchList/SearchListItemCards.tsx
+++ b/src/2-Widgets/SearchList/SearchListItemCards.tsx
@@ -6,9 +6,9 @@ import { RoleEnum } from '../../0-Assets/field-sync/input-config-sync/profile-fi
 import { LabelListItem } from '../../0-Assets/field-sync/input-config-sync/search-config';
 import formatRelativeDate, { calculateAge } from '../../1-Utilities/dateFormat';
 import { useAppSelector } from '../../1-Utilities/hooks';
-import { ContentArchivePreview } from '../../11-Models/ContentArchivePage';
+import { ContentArchivePreview, getDefaultThumbnail } from '../../11-Models/ContentArchivePage';
 import { makeAbbreviatedText, makeDisplayText } from '../../1-Utilities/utilities';
-import { CircleImage, ProfileImage } from '../ImageWidgets';
+import { CircleImage, ContentThumbnailImage, ProfileImage } from '../ImageWidgets';
 
 
 //Assets
@@ -181,14 +181,10 @@ export const PrayerRequestCommentItem = ({...props}:{key:any, prayerRequestComme
 
 export const ContentArchiveItem = ({...props}:{key:any, content:ContentListItem, onClick?:(id:number, item:ContentListItem)=>void, primaryButtonText?:string, onPrimaryButtonClick?:(id:number, item:ContentListItem)=>void, alternativeButtonText?:string, onAlternativeButtonClick?:(id:number, item:ContentListItem)=>void}) => {
     const userRole:string = useAppSelector((state) => state.account.userProfile.userRole);
+    console.log('Rendering Card', props.content.contentID, props.content.image);
     return (
-    <div key={props.key} className='search-item' onClick={()=>props.onClick && props.onClick(props.content.contentID, props.content)} >       
-        <ContentArchivePreview
-            url={props.content.url}
-            source={props.content.source}
-            maxWidth={300}
-            height={150}
-        />
+    <div key={props.key} className='search-item' onClick={()=>props.onClick && props.onClick(props.content.contentID, props.content)} >    
+        <ContentThumbnailImage src={props.content.image} defaultSrc={getDefaultThumbnail(props.content.source)} className='image-wide' />
         {(userRole === RoleEnum.ADMIN) && <label className='id'>#{props.content.contentID}</label>}
         <div className='detail-box'>
             <p key={'type'} className='detail-label-primary'>{props.content.type}</p>

--- a/src/index.scss
+++ b/src/index.scss
@@ -177,7 +177,7 @@ textarea {
   }
 }
 
-.circle-image {
+.circle-image, .thumbnail-image {
   object-fit: contain;
   border-radius: calc(2 * $radius);
   margin: 0 auto 1.0rem auto;


### PR DESCRIPTION
# Portal: Update for Mobile Content Page

## New Fields:
- Title
- Description
- Thumbnail URL
- Like Count

## New Features & Changes
### Thumbnail
- New Image Widget to render ContentThumbnail or default
- Thumbnail Image Upload/clear
- Display Thumbnail instead of rendering Content Preview
    - Repurpose `Update` toggle to switch between preview and thumbnail
- Display Thumbnail or default in list view on the right side
- Delete page renders thumbnail

#### Fetch Meta Data
- Requires Main Content URL, Source, Type
- Stateless Utility Service to return thumbnail, title, description
- Logic and Fetch handled on Server

![Screenshot 2024-06-08 041233](https://github.com/PEW35MINISTRY/portal/assets/53985473/510c60f1-359b-4995-99e2-b3900ddc69ab)
![Screenshot 2024-06-08 041249](https://github.com/PEW35MINISTRY/portal/assets/53985473/a783c65c-ac57-4bd1-9dfb-103a780fd51a)
![Screenshot 2024-06-08 041305](https://github.com/PEW35MINISTRY/portal/assets/53985473/a3baf03f-71b5-4d92-91cf-e110eb16e243)
