### PR TITLE
[95] Portal | Content Type Syncing with Source

### DIFF
--- a/src/0-Assets/field-sync/input-config-sync/content-field-config.ts
+++ b/src/0-Assets/field-sync/input-config-sync/content-field-config.ts
@@ -40,6 +40,13 @@ export const MOBILE_CONTENT_SUPPORTED_SOURCES:ContentSourceEnum[] = [
     ContentSourceEnum.THROUGH_THE_WORD
 ];
 
+export const MOBILE_CONTENT_SUPPORTED_TYPES_MAP:Map<ContentSourceEnum, ContentTypeEnum[]> = new Map([
+    [ContentSourceEnum.YOUTUBE, [ContentTypeEnum.VIDEO]],
+    [ContentSourceEnum.GOT_QUESTIONS, [ContentTypeEnum.ARTICLE]],
+    [ContentSourceEnum.BIBLE_PROJECT, [ContentTypeEnum.ARTICLE]],
+    [ContentSourceEnum.THROUGH_THE_WORD, [ContentTypeEnum.ARTICLE]]
+]);
+
 //TS can't extend enum, but object operates similar
 export const ContentSearchFilterEnum = {
     ...ContentSourceEnum,

--- a/src/2-Widgets/SearchList/SearchListItemCards.tsx
+++ b/src/2-Widgets/SearchList/SearchListItemCards.tsx
@@ -181,7 +181,7 @@ export const PrayerRequestCommentItem = ({...props}:{key:any, prayerRequestComme
 
 export const ContentArchiveItem = ({...props}:{key:any, content:ContentListItem, onClick?:(id:number, item:ContentListItem)=>void, primaryButtonText?:string, onPrimaryButtonClick?:(id:number, item:ContentListItem)=>void, alternativeButtonText?:string, onAlternativeButtonClick?:(id:number, item:ContentListItem)=>void}) => {
     const userRole:string = useAppSelector((state) => state.account.userProfile.userRole);
-    console.log('Rendering Card', props.content.contentID, props.content.image);
+
     return (
     <div key={props.key} className='search-item' onClick={()=>props.onClick && props.onClick(props.content.contentID, props.content)} >    
         <ContentThumbnailImage src={props.content.image} defaultSrc={getDefaultThumbnail(props.content.source)} className='image-wide' />


### PR DESCRIPTION
# [95] Portal | Content Type Syncing with Source
1. Indicating Relevant Mobile Supported Content Types
2. Syncing recommended type on source selection

**Note: This is setting the default, option still available to change selection and no validations.  May add these down the road, but currently want to keep open for submission to database and then only filter on displaying valid data for mobile.

<img width="693" alt="Screenshot 2024-07-22 at 8 27 10 PM" src="https://github.com/user-attachments/assets/7de50d2c-7ea2-426b-8868-917b24b02100">

<img width="665" alt="Screenshot 2024-07-22 at 8 27 32 PM" src="https://github.com/user-attachments/assets/2ba1295c-08da-4273-939d-57f381803c16">



**Comment: I know dependent variables aren't ideal; maybe at some point we combine options to single enum list `YOUTUBE_VIDEO`
