### PR TITLE
147 | PORTAL | Log S3 Updates

### DIFF
--- a/src/0-Assets/field-sync/api-type-sync/utility-types.ts
+++ b/src/0-Assets/field-sync/api-type-sync/utility-types.ts
@@ -30,16 +30,12 @@ export enum LogLocation {
 }
 
 export enum LogType {
-    ALERT = 'ALERT', 
     ERROR = 'ERROR', 
     WARN = 'WARN', 
     DB = 'DB', 
     AUTH = 'AUTH', 
     EVENT = 'EVENT',
 }
-
-//Alert are saved as Error, but also send email
-export const SUPPORTED_LOG_TYPES:LogType[] = Object.values(LogType).filter(t => t !== LogType.ALERT);
 
 //JSON form of LOG_ENTRY
 export type LogListItem = { 

--- a/src/1-Utilities/dateFormat.ts
+++ b/src/1-Utilities/dateFormat.ts
@@ -23,8 +23,8 @@ export const formatNumberOrdinal = (n:number):string =>
   
   
   //Relative Date Rules
-const formatRelativeDate = (startDate:Date|string, endDate?:Date|string, options?:{shortForm?:boolean, includeHours?:boolean, markPassed?:boolean}):string => {
-    options = {shortForm:true, includeHours:true, markPassed:false, ...options}; //Apply defaults & inputted overrides
+const formatRelativeDate = (startDate:Date|string, endDate?:Date|string, options?:{shortForm?:boolean, includeHours?:boolean, markPassed?:boolean, timezoneOffset?:number}):string => {
+    options = {shortForm:true, includeHours:true, markPassed:false, timezoneOffset:0, ...options}; //Apply defaults & inputted overrides
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     let text = '';
@@ -40,6 +40,10 @@ const formatRelativeDate = (startDate:Date|string, endDate?:Date|string, options
 
     const isPassed:boolean = (options.markPassed === true) && (endDate !== undefined) && (endDate > today);
   
+    //Optional: Adjust timezone comparison
+    startDate = new Date(startDate.getTime() + ((options.timezoneOffset || 0) * 60 * 60 * 1000));
+    if(endDate) endDate = new Date(endDate.getTime() + ((options.timezoneOffset || 0) * 60 * 60 * 1000));
+
     //Date is currently onGoing
     let currentlyOnGoing = false;
     if(today > startDate && endDate != undefined && today < endDate) {

--- a/src/1-Utilities/dateFormat.ts
+++ b/src/1-Utilities/dateFormat.ts
@@ -23,8 +23,8 @@ export const formatNumberOrdinal = (n:number):string =>
   
   
   //Relative Date Rules
-const formatRelativeDate = (startDate:Date|string, endDate?:Date|string, options?:{shortForm?:boolean, includeHours?:boolean, markPassed?:boolean, timezoneOffset?:number}):string => {
-    options = {shortForm:true, includeHours:true, markPassed:false, timezoneOffset:0, ...options}; //Apply defaults & inputted overrides
+const formatRelativeDate = (startDate:Date|string, endDate?:Date|string, options?:{shortForm?:boolean, includeHours?:boolean, markPassed?:boolean}):string => {
+    options = {shortForm:true, includeHours:true, markPassed:false, ...options}; //Apply defaults & inputted overrides
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     let text = '';
@@ -40,10 +40,6 @@ const formatRelativeDate = (startDate:Date|string, endDate?:Date|string, options
 
     const isPassed:boolean = (options.markPassed === true) && (endDate !== undefined) && (endDate > today);
   
-    //Optional: Adjust timezone comparison
-    startDate = new Date(startDate.getTime() + ((options.timezoneOffset || 0) * 60 * 60 * 1000));
-    if(endDate) endDate = new Date(endDate.getTime() + ((options.timezoneOffset || 0) * 60 * 60 * 1000));
-
     //Date is currently onGoing
     let currentlyOnGoing = false;
     if(today > startDate && endDate != undefined && today < endDate) {

--- a/src/1-Utilities/dateFormat.ts
+++ b/src/1-Utilities/dateFormat.ts
@@ -9,9 +9,10 @@ const MONTH_SHORT:string[] = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', '
 const MONTH_LONG:string[] = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
 export const getFutureDate = (date:Date = new Date(), days:number = 0, hours:number = 0):Date => {
-    date.setDate(date.getDate() + days);
-    date.setHours(date.getHours() + hours);
-    return date;
+    const newDate = new Date(date);
+    newDate.setDate(date.getDate() + days);
+    newDate.setHours(date.getHours() + hours, 0, 0, 0);
+    return newDate;
   }
   
 export const formatNumberOrdinal = (n:number):string => 
@@ -25,7 +26,7 @@ export const formatNumberOrdinal = (n:number):string =>
 const formatRelativeDate = (startDate:Date|string, endDate?:Date|string, options?:{shortForm?:boolean, includeHours?:boolean, markPassed?:boolean}):string => {
     options = {shortForm:true, includeHours:true, markPassed:false, ...options}; //Apply defaults & inputted overrides
     const today = new Date();
-    today.setHours(0);
+    today.setHours(0, 0, 0, 0);
     let text = '';
 
     //Handle Date type validations

--- a/src/1-Utilities/hooks.tsx
+++ b/src/1-Utilities/hooks.tsx
@@ -107,18 +107,20 @@ export const useInterval = ({ interval, callback, cancelInterval }:{interval:num
 
 
 export const useStatusInterval = ({interval, callback, statusInterval, statusCallback, cancelInterval}: {interval:number, callback:() => void, statusInterval:number, statusCallback:(timeLeft:number) => void, cancelInterval?:() => boolean}) => {
-	const nextCompletionTimestamp = useRef<number>(new Date().getTime() + interval);
+	const nextCompletionTimestamp = useRef<number>(0);
     const timerRef = useRef<NodeJS.Timeout|undefined>(undefined);
 
     useEffect(() => {
-        if(interval <= 0 || interval < statusInterval) return;
+        if(interval <= 0 || statusInterval <= 0 || interval < statusInterval) return;
+
+		nextCompletionTimestamp.current = new Date().getTime() + interval;
 
         timerRef.current = setInterval(() => {
             const now:number = new Date().getTime();
             const timeLeft:number = nextCompletionTimestamp.current - now;
 
             //Main Callback
-            if(timeLeft <= interval) {
+            if(timeLeft <= statusInterval) {
                 callback();
                 nextCompletionTimestamp.current = now + interval;
             } else

--- a/src/1-Utilities/hooks.tsx
+++ b/src/1-Utilities/hooks.tsx
@@ -49,12 +49,12 @@ export const notify = (text:string, type:ToastStyle = ToastStyle.INFO, callback?
 
 export const processAJAXError = (error:AXIOSError, callback?:Function) => {
   const status:number = error?.response?.status || 500;
-  if (error?.response?.data && 'action' in error?.response?.data)
+  if(error?.response?.data && 'action' in error?.response?.data)
     console.error(error.message, error?.response?.data.action);
   else
     console.error(error.message, error?.response?.data.notification);
 
-  notify(error?.response?.data.notification || '', 
+  notify(error?.response?.data.notification || 'Server is Offline', 
       (status < 300) ? ToastStyle.SUCCESS
       : (status < 400) ? ToastStyle.INFO
       : (status < 500) ? ToastStyle.WARN

--- a/src/1-Utilities/hooks.tsx
+++ b/src/1-Utilities/hooks.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { toast } from 'react-toastify';
@@ -77,37 +77,64 @@ export const useQuery = () => {
  * * Optional cancelInterval() check *
  *************************************/
 export const useInterval = ({ interval, callback, cancelInterval }:{interval:number, callback:() => void, cancelInterval?:() => boolean}) => {
-    const [currentInterval, setCurrentInterval] = useState<number>(interval);
-
     useEffect(() => {
         let timer:NodeJS.Timeout|undefined = undefined;
 
         const startInterval = () => {
-            timer = setInterval(() => {
-                if(cancelInterval?.()) {
-                    if(timer) {
-                        clearInterval(timer);
-                        timer = undefined;
-                    }
-                } else {
-                    callback();
-                }
-            }, currentInterval);
+			timer = setInterval(() => {
+				if(cancelInterval?.()) {
+					if(timer) {
+						clearInterval(timer);
+						timer = undefined;
+					}
+				} else {
+					callback();
+				}
+			}, interval);
         };
 
-        /* Restart Interval */
+        /* Initiate/Stop Interval */
         if(interval > 0)
-          startInterval();
+			startInterval();
         else if(timer) {
-          clearInterval(timer);
-          timer = undefined;
+        	clearInterval(timer);
+        	timer = undefined;
         }
 
         return () => { timer && clearInterval(timer); }
-    }, [currentInterval, callback, cancelInterval]);
+    }, [interval, cancelInterval]);
+};
 
-    // Update interval duration
+
+export const useStatusInterval = ({interval, callback, statusInterval, statusCallback, cancelInterval}: {interval:number, callback:() => void, statusInterval:number, statusCallback:(timeLeft:number) => void, cancelInterval?:() => boolean}) => {
+	const nextCompletionTimestamp = useRef<number>(new Date().getTime() + interval);
+    const timerRef = useRef<NodeJS.Timeout|undefined>(undefined);
+
     useEffect(() => {
-        setCurrentInterval(interval);
-    }, [interval]);
+        if(interval <= 0 || interval < statusInterval) return;
+
+        timerRef.current = setInterval(() => {
+            const now:number = new Date().getTime();
+            const timeLeft:number = nextCompletionTimestamp.current - now;
+
+            //Main Callback
+            if(timeLeft <= interval) {
+                callback();
+                nextCompletionTimestamp.current = now + interval;
+            } else
+            	statusCallback(timeLeft);
+
+            if(cancelInterval?.()) {
+                clearInterval(timerRef.current!);
+                timerRef.current = undefined;
+            }
+        }, statusInterval);
+
+        return () => {
+            if(timerRef.current) {
+                clearInterval(timerRef.current);
+                timerRef.current = undefined;
+            }
+        };
+    }, [interval, statusInterval, cancelInterval]);
 };

--- a/src/100-App/App.scss
+++ b/src/100-App/App.scss
@@ -219,6 +219,7 @@
 
                 h5 {
                     margin: 0;
+                    color: white;
                     font-size: 0.6rem;
                 }
             }

--- a/src/100-App/app-types.tsx
+++ b/src/100-App/app-types.tsx
@@ -29,19 +29,15 @@ export enum ModelPopUpAction {
   NEW = 'new',
   EDIT = 'edit',
   DELETE = 'delete',
+
   IMAGE = 'image',
   COMMENT = 'comment',
   ANNOUNCEMENT = 'announcement',
   EVENT = 'event',
-  SETTINGS = 'settings'
-}
 
-export enum PopUpAction {
-  NONE = '',
-  NEW = 'new',
-  DELETE = 'delete',
   SEARCH = 'search',
-  SETTINGS = 'settings'
+  SETTINGS = 'settings',
+  'EXPORT' = 'export',
 }
 
 export type AXIOSError = {

--- a/src/11-Models/UserEditPage.tsx
+++ b/src/11-Models/UserEditPage.tsx
@@ -621,7 +621,7 @@ const UserEditPage = () => {
                                 setImage(undefined);
                                 notify(`Profile Image Deleted`, ToastStyle.SUCCESS, () => (editingUserID === userID) && dispatch(updateProfileImage(undefined)))})
                             .catch((error) => processAJAXError(error))}
-                        onUpload={(imageFile: { name: string; type: string; })=> axios.post(`${process.env.REACT_APP_DOMA}IN/api/user/${editingUserID}/image/${imageFile.name}`, imageFile, { headers: { 'jwt': jwt, 'Content-Type': imageFile.type }} )
+                        onUpload={(imageFile: { name: string; type: string; })=> axios.post(`${process.env.REACT_APP_DOMAIN}/api/user/${editingUserID}/image/${imageFile.name}`, imageFile, { headers: { 'jwt': jwt, 'Content-Type': imageFile.type }} )
                             .then(response => {
                                 updatePopUpAction(ModelPopUpAction.NONE);
                                 setImage(response.data);

--- a/src/12-Features/Log/LogPage.tsx
+++ b/src/12-Features/Log/LogPage.tsx
@@ -432,26 +432,23 @@ const LOG_TYPE_COLORS: { [key in LogType]:string } = {
 
 const getLogColor = (type:LogType):string => LOG_TYPE_COLORS[type] || 'black';
 
-const formatLogDate = (originalDate:Date, longForm:boolean = false, showLocalTime:boolean = false):string => {
-    const date:Date = showLocalTime ? new Date(originalDate.getTime() - originalDate.getTimezoneOffset() * 60000) : originalDate; //modified new object to still use date utilities
-    
-    return (!(date instanceof Date) || isNaN(date.getTime())) ? '[]' :
-        '['
-        + String(date.getMonth() + 1).padStart(2, '0')
-        + '-'
-        + String(date.getDate()).padStart(2, '0')
-        + (longForm ? '-'
-            + date.getFullYear() : '')
-        + ' '
-        + String(date.getHours()).padStart(2, '0')
-        + ':'
-        + String(date.getMinutes()).padStart(2, '0')
-        + (longForm ? ':'
-            + String(date.getSeconds()).padStart(2, '0')
-            + '.'
-            + String(date.getMilliseconds()).padStart(3, '0') : '')
-        + ']';
-}
+const formatLogDate = (date:Date, longForm:boolean = false, showLocalTime:boolean = false):string =>
+    (!(date instanceof Date) || isNaN(date.getTime())) ? '[]' :
+    '['
+    + String(showLocalTime ? date.getMonth() + 1 : date.getUTCMonth() + 1).padStart(2, '0')
+    + '-'
+    + String(showLocalTime ? date.getDate() : date.getUTCDate()).padStart(2, '0')
+    + (longForm ? '-'
+        + (showLocalTime ? date.getFullYear() : date.getUTCFullYear()) : '')
+    + ' '
+    + String(showLocalTime ? date.getHours() : date.getUTCHours()).padStart(2, '0')
+    + ':'
+    + String(date.getMinutes()).padStart(2, '0')
+    + (longForm ? ':'
+        + String(showLocalTime ? date.getSeconds() : date.getUTCSeconds()).padStart(2, '0')
+        + '.'
+        + String(showLocalTime ? date.getMilliseconds() : date.getUTCMilliseconds()).padStart(3, '0') : '')
+    + ']';
 
 
 export function formatUTCDate(timestamp:number):string {

--- a/src/12-Features/Log/LogPage.tsx
+++ b/src/12-Features/Log/LogPage.tsx
@@ -67,16 +67,14 @@ const LogPage = () => {
     }
 
     /* Update State and Fetch Default */
-    const updateLogType = (newType:LogType, reset:boolean = true, newAction?:ModelPopUpAction|undefined) => {
+    const updateLogType = (newType:LogType, reset:boolean = true) => {
         if(Object.values(LogType).includes(newType) && type !== newType) {
-            const targetAction:ModelPopUpAction = (newAction && SUPPORTED_POP_UP_ACTIONS.includes(newAction)) ? newAction : ModelPopUpAction.NONE;
-            if(targetAction != popUpAction) setPopUpAction(targetAction);
+            navigate(`/portal/logs/${newType.toLowerCase()}`, { replace: true });
             setType(newType);
-            navigate(`/portal/logs/${newType.toLowerCase()}${reset ? '' : `/${targetAction}`}`, { replace: true });
+            setPopUpAction(ModelPopUpAction.NONE);            
 
             if(reset) {
                 executeSearch({ type: newType, searchTerm: ''}, false);
-                // setPopUpAction(targetAction);
                 setSearchTerm('');
                 setCumulativeIndex(0);
             }            

--- a/src/12-Features/Log/LogPage.tsx
+++ b/src/12-Features/Log/LogPage.tsx
@@ -9,9 +9,9 @@ import { blueColor, blueDarkColor, PageState, PopUpAction, redColor } from '../.
 import { ImageDefaultEnum } from '../../2-Widgets/ImageWidgets';
 import { getEnvironment } from '../../1-Utilities/utilities';
 import { NewLogPopup, SearchLogPopup, SettingsLogPopup, SettingsProperty } from './log-widgets';
+import formatRelativeDate from '../../1-Utilities/dateFormat';
 
 import './log.scss';
-import formatRelativeDate from '../../1-Utilities/dateFormat';
 
 
 const LogPage = () => {
@@ -254,7 +254,7 @@ const LogPage = () => {
                     [
                         'Location', new SettingsProperty<LogLocation>(location, updateLogLocation, Object.values(LogLocation))
                     ],
-                    [   'Refresh', new SettingsProperty<number>( refreshInterval, setRefreshInterval,
+                    [   'Refresh', new SettingsProperty<number>( refreshInterval, (value:number)=>setRefreshInterval(Number(value)),
                             [0, 30000, 60000, 150000, 300000, 900000], 
                             [0, 30000, 60000, 150000, 300000, 900000].map(m => formatIntervalTime(m))
                     )]

--- a/src/12-Features/Log/LogPage.tsx
+++ b/src/12-Features/Log/LogPage.tsx
@@ -357,10 +357,10 @@ const LOG_TYPE_COLORS: { [key in LogType]:string } = {
 const getLogColor = (type:LogType):string => LOG_TYPE_COLORS[type] || 'black';
 
 const calculateDays = (date:Date, days:number):Date => {
-    const previousDate:Date = new Date(date);
-    previousDate.setHours(0, 0, 0, 0);
-    previousDate.setDate(previousDate.getDate() + days);
-    return previousDate;
+    const d:Date = new Date(date);
+    d.setHours(0, 0, 0, 0);
+    d.setDate(d.getDate() + days);
+    return d;
 }
 
 const formatLogDate = (date:Date, longForm:boolean = false):string => (!(date instanceof Date) || isNaN(date.getTime())) ? '[]' :

--- a/src/12-Features/Log/LogPage.tsx
+++ b/src/12-Features/Log/LogPage.tsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { processAJAXError, useAppSelector, useInterval } from '../../1-Utilities/hooks';
-import { LogListItem, LogLocation, LogType, SUPPORTED_LOG_TYPES } from '../../0-Assets/field-sync/api-type-sync/utility-types';
+import { LogListItem, LogLocation, LogType } from '../../0-Assets/field-sync/api-type-sync/utility-types';
 import { ENVIRONMENT_TYPE, makeDisplayText } from '../../0-Assets/field-sync/input-config-sync/inputField';
 import FullImagePage from '../Utility-Pages/FullImagePage';
 import { blueColor, blueDarkColor, PageState, PopUpAction, redColor } from '../../100-App/app-types';
@@ -37,7 +37,7 @@ const LogPage = () => {
     useEffect(() => {
         if(jwt.length === 0) return;
 
-        const targetType:LogType|undefined = SUPPORTED_LOG_TYPES.find((t) => t === kind?.toUpperCase());
+        const targetType:LogType|undefined = Object.values(LogType).find((t) => t === kind?.toUpperCase());
         const targetAction:PopUpAction|undefined = SUPPORTED_POP_UP_ACTIONS.find((a) => a === action?.toLowerCase());     
         
         if(targetType) {
@@ -68,7 +68,7 @@ const LogPage = () => {
 
     /* Update State and Fetch Default */
     const updateLogType = (newType:LogType, reset:boolean = true) => {
-        if(SUPPORTED_LOG_TYPES.includes(newType) && type !== newType) {
+        if(Object.values(LogType).includes(newType) && type !== newType) {
             navigate(`/portal/logs/${newType.toLowerCase()}${reset ? '' : `/${popUpAction}`}`, { replace: true });
             setType(newType);
 
@@ -76,6 +76,7 @@ const LogPage = () => {
                 executeSearch({ type: newType, searchTerm: ''});
                 setPopUpAction(PopUpAction.NONE);
                 setSearchTerm('');
+                setCumulativeIndex(0);
             }            
         }
     }
@@ -154,7 +155,7 @@ const LogPage = () => {
                         executeSearch({ type: LogType[e.target.value as keyof typeof LogType] });
                     }}>
                         <option value='DEFAULT' disabled hidden>Default</option>
-                        {SUPPORTED_LOG_TYPES.map((logType) => (
+                        {Object.values(LogType).map((logType) => (
                             <option key={logType} value={logType}>
                                 {makeDisplayText(logType)}
                             </option>
@@ -220,7 +221,7 @@ const LogPage = () => {
                 <SettingsLogPopup
                 propertyMap={new Map<string, SettingsProperty<any>>([
                     [
-                        'Type', new SettingsProperty<LogType>(type, updateLogType, SUPPORTED_LOG_TYPES)
+                        'Type', new SettingsProperty<LogType>(type, updateLogType, Object.values(LogType))
                     ],
                     [
                         'Location', new SettingsProperty<LogLocation>(location, updateLogLocation, Object.values(LogLocation))
@@ -312,7 +313,6 @@ const LogEntryItem: React.FC<{ LogListItem: LogListItem }> = ({ LogListItem: { t
 
 /* UTILITIES */
 const LOG_TYPE_COLORS: { [key in LogType]:string } = {
-    [LogType.ALERT]: redColor,
     [LogType.ERROR]: redColor,
     [LogType.WARN]: '#daa520', //goldenrod
     [LogType.DB]: '#470047', //Purple

--- a/src/12-Features/Log/log-widgets.tsx
+++ b/src/12-Features/Log/log-widgets.tsx
@@ -15,7 +15,7 @@ import { ToastStyle } from '../../100-App/app-types';
 export const SearchLogPopup = ({ type, location, searchTerm, setSearchTerm, startDate, setStartDate, endDate, setEndDate, combineDuplicates, setCombineDuplicates,
     onSearch, onCancel }: {
         type:LogType, location:LogLocation, searchTerm:string, setSearchTerm:(value: string) => void, startDate?: Date, setStartDate: (value:Date) => void, endDate?:Date, setEndDate:(value:Date) => void, combineDuplicates:boolean, setCombineDuplicates:(value:boolean) => void,
-        onSearch: (criteria: { type?:LogType, searchTerm?:string, endTimestamp?:number, cumulativeIndex?:number }) => void, onCancel?:() => void,
+        onSearch: (criteria: { type?:LogType, searchTerm?:string, location?:LogLocation, endTimestamp?:number, cumulativeIndex?:number }) => void, onCancel?:() => void,
     }) => {
     const searchRef = useRef<HTMLInputElement | null>(null);
     const [searchType, setSearchType] = useState<LogType>(type); //Separate to not trigger a search
@@ -32,6 +32,8 @@ export const SearchLogPopup = ({ type, location, searchTerm, setSearchTerm, star
     const onSearchHandler = () => {
         onSearch({
             type: searchType,
+            location: searchLocation,
+            //searchTerm is provided with LogState.searchTerm
             endTimestamp: endDate?.getTime(),
             cumulativeIndex: startIndex,
         });

--- a/src/12-Features/Log/log-widgets.tsx
+++ b/src/12-Features/Log/log-widgets.tsx
@@ -266,7 +266,7 @@ export const ExportLogPopup = ({ propertyMap, onCancel }: { propertyMap: Map<str
 ************/
 export const SettingsLogPopup = ({ propertyMap, onCancel }: { propertyMap: Map<string, SettingsProperty<any>>, onCancel?: () => void }) => {
     const jwt:string = useAppSelector((state) => state.account.jwt);
-    const type:LogType = useMemo(() => LogType[propertyMap.get('Location')?.value as keyof typeof LogType] ?? LogType.ERROR, [propertyMap]); //Uses Label Name
+    const type:LogType = useMemo(() => LogType[propertyMap.get('Type')?.value as keyof typeof LogType] ?? LogType.ERROR, [propertyMap]); //Uses Label Name
     const location:LogLocation = useMemo(() => LogLocation[propertyMap.get('Location')?.value as keyof typeof LogLocation] ?? LogLocation.LOCAL, [propertyMap]); //Uses Label Name
 
     return (

--- a/src/12-Features/Log/log-widgets.tsx
+++ b/src/12-Features/Log/log-widgets.tsx
@@ -259,6 +259,18 @@ export const SettingsLogPopup = ({ propertyMap, onCancel }: { propertyMap: Map<s
                         }>Reset ↺</button>
                 }
 
+                {/* Update Athena Partitions for S3 Log Search */}
+                {(location === LogLocation.S3) &&
+                    <button className='alternative-button' type='button' onClick={() => 
+                        axios.post(`${process.env.REACT_APP_DOMAIN}/api/admin/log/athena-partition`, {}, { headers: { jwt } })
+                        .then((response) => {
+                            notify('Athena Partitioned', ToastStyle.SUCCESS);
+                            onCancel && onCancel();
+                        })
+                        .catch((error) => processAJAXError(error))
+                        }>Update Partitions ↺</button>
+                }
+
                 <button className='alternative-button' type='button' onClick={() => downloadLog(false)}>View ⇒</button>
 
                 <button className='alternative-button' type='button' onClick={() => downloadLog(true)}>Download ⭳</button>

--- a/src/12-Features/Log/log-widgets.tsx
+++ b/src/12-Features/Log/log-widgets.tsx
@@ -83,7 +83,7 @@ export const SearchLogPopup = ({ type, location, searchTerm, setSearchTerm, star
                         <option key={'duplicate-no'} value={'false'}>No</option>
                     </select>
 
-                    {endDate && 
+                    {(endDate && searchLocation === LogLocation.LOCAL) &&
                         <>
                             <label>Index</label>
                             <input type='number' value={startIndex} onChange={(e) => setStartIndex(Number(e.target.value))} min={0} autoComplete='off'/>
@@ -333,7 +333,7 @@ export const SettingsLogPopup = ({ propertyMap, onCancel }: { propertyMap: Map<s
                             onCancel && onCancel();
                         })
                         .catch((error) => processAJAXError(error))
-                        }>Reset ↺</button>
+                        }>Reset File ↺</button>
                 }
 
                 {/* Update Athena Partitions for S3 Log Search */}
@@ -345,21 +345,8 @@ export const SettingsLogPopup = ({ propertyMap, onCancel }: { propertyMap: Map<s
                             onCancel && onCancel();
                         })
                         .catch((error) => processAJAXError(error))
-                        }>Update Partitions ↺</button>
+                        }>Update Search Partitions ↺</button>
                 }
-
-                <button className='alternative-button' type='button' onClick={() => downloadLog(false)}>View ⇒</button>
-
-                <button className='alternative-button' type='button' onClick={() => downloadLog(true)}>Download ⭳</button>
-
-                <button className='alternative-button' type='button' onClick={() => 
-                    axios.post(`${process.env.REACT_APP_DOMAIN}/api/admin/log/${type}/report?location=${location}`, {}, { headers: { jwt } })
-                        .then((response: { data: LogListItem }) => {
-                            notify(`${makeDisplayText(type)} Report Emailed`, ToastStyle.SUCCESS);
-                            onCancel && onCancel();
-                        })
-                        .catch((error) => processAJAXError(error))
-                    }>Send Report 📃</button>
 
                 <button className='alternative-button cancel-button' type='button' onClick={() => onCancel && onCancel()}>Cancel</button>
             </div>

--- a/src/12-Features/Log/log.scss
+++ b/src/12-Features/Log/log.scss
@@ -154,6 +154,7 @@
 
              .log-entry-details {
 
+                 .log-entry-timestamp,
                  .log-entry-message,
                  .log-entry-duplicate,
                  .log-entry-trace {

--- a/src/12-Features/Log/log.scss
+++ b/src/12-Features/Log/log.scss
@@ -209,14 +209,6 @@
                  }
              }
          }
-
-         .next-page-button {
-            width: 100%;
-            margin-bottom: 0;
-            border-left: none;
-            border-right: none;
-            border-bottom: none;
-        }
      }
 
      #search-log-pop-up,
@@ -296,3 +288,20 @@
         }
     }    
  }
+
+ /* Renders Outside in FullImagePage */
+ #previous-page-button-box {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    margin-top: auto;
+
+    .previous-page-button,
+    .next-page-button {
+        width: 100%;
+        margin-bottom: 0;
+        border-left: none;
+        border-right: none;
+        border-bottom: none;
+    }
+}

--- a/src/12-Features/Log/log.scss
+++ b/src/12-Features/Log/log.scss
@@ -29,6 +29,10 @@
                  padding-bottom: 0;
                  margin-bottom: 0;
              }
+
+             .icon-button-label.hide-tablet {
+                @include HIDE-ON-TABLET;
+             }
          }
 
          .typeSelection {
@@ -216,6 +220,7 @@
      }
 
      #search-log-pop-up,
+     #export-log-pop-up,
      #new-log-pop-up,
      #settings-log-pop-up {
          display: flex;
@@ -276,6 +281,7 @@
         }
     }
 
+    #export-log-pop-up,
     #settings-log-pop-up {
         .alternative-button {
             margin: 0.25rem 0;

--- a/src/12-Features/Utility-Pages/FullImagePage.tsx
+++ b/src/12-Features/Utility-Pages/FullImagePage.tsx
@@ -3,7 +3,7 @@ import { getDefaultImage, ImageDefaultEnum } from '../../2-Widgets/ImageWidgets'
 
 import './fullImagePage.scss';
 
-const FullImagePage = (props:{imageType?:ImageDefaultEnum, fullPage?:boolean, backgroundColor?:string, message?:string, messageColor?:string, primaryButtonText?:string, onPrimaryButtonClick?:()=>void, alternativeButtonText?:string, onAlternativeButtonClick?:()=>void}) => { 
+const FullImagePage = (props:{imageType?:ImageDefaultEnum, fullPage?:boolean, backgroundColor?:string, message?:string, messageColor?:string, primaryButtonText?:string, onPrimaryButtonClick?:()=>void, alternativeButtonText?:string, onAlternativeButtonClick?:()=>void, footer?:JSX.Element}) => { 
 
   return (
       <div id='full-image-page' className={props.fullPage ? 'full-page' : ''} style={{backgroundColor:props.backgroundColor}}>
@@ -13,6 +13,7 @@ const FullImagePage = (props:{imageType?:ImageDefaultEnum, fullPage?:boolean, ba
             {props.message && <h2 style={{color:props.messageColor}} >{props.message}</h2>}
             {props.primaryButtonText && <button className='primary-button' onClick={props.onPrimaryButtonClick} >{props.primaryButtonText}</button>}
             {props.alternativeButtonText && <button className='alternative-button' onClick={props.onAlternativeButtonClick} >{props.alternativeButtonText}</button>}
+            {props.footer}
         </div>}
       </div>);
   }

--- a/src/2-Widgets/Form/form.scss
+++ b/src/2-Widgets/Form/form.scss
@@ -140,6 +140,7 @@
                     h5 {
                         margin-left: 1.0rem;
                         font-weight: 500;
+                        color: black;
                     }
                     
                     button {

--- a/src/2-Widgets/PartnershipWidgets.tsx
+++ b/src/2-Widgets/PartnershipWidgets.tsx
@@ -192,7 +192,7 @@ export const PartnershipContract = ({...props}:{key:string, partner:PartnerListI
                 <div className='form-page-block center-absolute-inside' onClick={(e)=>e.stopPropagation()} >
                     <h1 className='name'>New Partner</h1>
                        
-                    <h6 className='contract' >{PARTNERSHIP_CONTRACT(userName, props.partner.displayName)}</h6>
+                    <p className='contract' >{PARTNERSHIP_CONTRACT(userName, props.partner.displayName)}</p>
     
                     <button className='submit-button' type='button' onClick={onAcceptPartnership}>Accept Partnership</button>
                     <button className='alternative-button'  type='button' onClick={onDeclinePartnership}>Decline</button>

--- a/src/index.scss
+++ b/src/index.scss
@@ -45,8 +45,8 @@ body {
   overflow: hidden;
 }
 
-
-.none, .hide {
+/* DISPLAY CONTROLS */
+@mixin HIDE {
   display: none;
   height: 0;
   width: 0;
@@ -54,16 +54,32 @@ body {
   padding: 0;
 }
 
-.hide-mobile {
+.none, .hide {
+  @include HIDE;
+}
+
+@mixin HIDE-ON-MOBILE {
   @media screen and (max-width: $screen-mobile-width) {
-    display: none;
-    height: 0;
-    width: 0;
-    margin: 0;
-    padding: 0;
+    @include HIDE;
   }
 }
 
+.hide-mobile {
+  @include HIDE-ON-MOBILE;
+}
+
+@mixin HIDE-ON-TABLET {
+  @media screen and (max-width: $screen-tablet-width) {
+    @include HIDE;
+  }
+}
+
+.hide-tablet {
+  @include HIDE-ON-TABLET;
+}
+
+
+/* ELEMENT DEFAULTS */
 div,
 label,
 button,
@@ -72,7 +88,8 @@ h2,
 h3,
 h4,
 h5,
-h6 {
+h6,
+p {
   background-color: transparent;
   border: none;
   border-radius: $radius;
@@ -131,14 +148,26 @@ label,
   color: $blue;
 }
 
+h4, h5 {
+  color: $red;
+}
+
 h5,
 h6,
+p,
 .text {
   font-family: 'Roboto';
   font-weight: 300;
   font-size: 1.0rem;
+  color: black;
 }
 
+h6 {
+  color: $blue;
+}
+
+
+/* INPUT DEFAULTS */
 input, select, textarea {
   text-align: left;
   margin: 0.25rem 0;
@@ -266,7 +295,8 @@ textarea {
   margin: auto;
 }
 
-//Animations
+
+/* ANIMATIONS */
 @keyframes zoom-pulse {
   0%,100% {
     transform: scale(1);


### PR DESCRIPTION
## Minor updates related to S3 Logs:
- Removed `Alert` LogType; still supported in route to trigger email before saving to `ERROR` file
- `useStatusInterval` hook used for auto fetch latest logs and countdown in the header
- `LogPage.searchPreviousDay` is the button at the bottom of the screen.  Locally this goes back a set index size in the txt file.  For S3 Logs, this goes backwards 1 day at a time.
- `LogEntryItem` holds state for list details.  For S3 Logs, the bottom "More Details" appears which fetches through the server for S3 body.  (Initial display is parsed from the S3 key).


**Server also supports downloading S3 Logs as txt file.  The server process is to fetch entries and stream as plain text which the browser interprets as a downloadable file.

![Screenshot 2025-02-20 230517](https://github.com/user-attachments/assets/0d65b8f0-2e17-47af-bb78-b7269caa5ca0)
