### PR TITLE
[162] Partnership Refactor

### DIFF
--- a/src/100-App/AppContent.tsx
+++ b/src/100-App/AppContent.tsx
@@ -142,7 +142,7 @@ const AppContent = () => {
       {label: '* HELP * SUPPORT *', route: `/portal/support`, activeIcon: SUPPORT_ICON_ACTIVE, inactiveIcon: SUPPORT_ICON},
       {label: 'Content Archive', route: '/portal/edit/content-archive/-1', activeIcon: CONTENT_ICON_ACTIVE, inactiveIcon: CONTENT_ICON, addRoute: '/portal/edit/content-archive/new', exclusiveRoleList: [RoleEnum.CONTENT_APPROVER, RoleEnum.ADMIN]},
       {label: 'Profile', route: `/portal/edit/profile/${userID}`, activeIcon: PROFILE_ICON_ACTIVE, inactiveIcon: PROFILE_ICON},
-      {label: 'Partnerships', route: `/portal/partnership/recent`, activeIcon: PARTNER_ICON_ACTIVE, inactiveIcon: PARTNER_ICON, exclusiveRoleList: [RoleEnum.ADMIN],
+      {label: 'Partnerships', route: `/portal/partnership/recent`, activeIcon: PARTNER_ICON_ACTIVE, inactiveIcon: PARTNER_ICON, addRoute: '/portal/partnership/recent/edit', exclusiveRoleList: [RoleEnum.ADMIN],
         subMenu: [{label: 'Fewer', route: `/portal/partnership/fewer`},
                   {label: 'Pending', route: `/portal/partnership/pending`}]
       },
@@ -268,8 +268,11 @@ const AppContent = () => {
                   {isPageAccessible('/edit/profile') && <Route path='/edit/profile/:id/:action' element={<UserEditPage/>}/>}
                   {isPageAccessible('/edit/profile') && <Route path='/edit/profile/:id/*' element={<UserEditPage/>}/>}
                   {isPageAccessible('/partnership/recent') && <Route path='/partnership/recent' element={<PartnershipPage view={PARTNERSHIP_VIEW.NEW_USERS} />}/>}
+                  {isPageAccessible('/partnership/recent') && <Route path='/partnership/recent/:action' element={<PartnershipPage view={PARTNERSHIP_VIEW.NEW_USERS} />}/>}
                   {isPageAccessible('/partnership/fewer') && <Route path='/partnership/fewer' element={<PartnershipPage view={PARTNERSHIP_VIEW.FEWER_PARTNERSHIPS} />}/>}
+                  {isPageAccessible('/partnership/fewer') && <Route path='/partnership/fewer/:action' element={<PartnershipPage view={PARTNERSHIP_VIEW.FEWER_PARTNERSHIPS} />}/>}
                   {isPageAccessible('/partnership/pending') && <Route path='/partnership/pending' element={<PartnershipPage view={PARTNERSHIP_VIEW.PENDING_PARTNERSHIPS} />}/>}
+                  {isPageAccessible('/partnership/pending') && <Route path='/partnership/pending/:action' element={<PartnershipPage view={PARTNERSHIP_VIEW.PENDING_PARTNERSHIPS} />}/>}
                   {isPageAccessible('/edit/circle') && <Route path='/edit/circle/:id/:action' element={<CircleEditPage/>}/>}
                   {isPageAccessible('/edit/circle') && <Route path='/edit/circle/:id/*' element={<CircleEditPage/>}/>}
                   {isPageAccessible('/edit/prayer-request') && <Route path='/edit/prayer-request/:id/:action' element={<PrayerRequestEditPage/>}/>}

--- a/src/100-App/app-types.tsx
+++ b/src/100-App/app-types.tsx
@@ -27,6 +27,7 @@ export enum PageState {
 export enum ModelPopUpAction {
   NONE = '',
   NEW = 'new',
+  EDIT = 'edit',
   DELETE = 'delete',
   IMAGE = 'image',
   COMMENT = 'comment',

--- a/src/11-Models/UserEditPage.tsx
+++ b/src/11-Models/UserEditPage.tsx
@@ -591,8 +591,8 @@ const UserEditPage = () => {
                         {userRole === RoleEnum.ADMIN ? (
                             <PartnershipStatusADMIN
                                 key={`User-Edit-Partnership-${editingUserID}-${newPartner.userID}-ADMIN`}
-                                user={({userID: editingUserID, image: image, displayName: getInputField('displayName'), firstName: getInputField('firstName')})}
-                                partner={newPartner}
+                                userID={editingUserID}
+                                partnerID={newPartner.userID}
                                 currentStatus={newPartner.status}
                                 onCancel={() => setNewPartner(undefined)}
                             />

--- a/src/12-Features/PartnershipPage.tsx
+++ b/src/12-Features/PartnershipPage.tsx
@@ -40,7 +40,7 @@ const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
     /* Select & Modify Partnership Status */
     const [selectedUser, setSelectedUser] = useState<ProfileListItem|undefined>(undefined); //undefined hides popup
     const [selectedPartner, setSelectedPartner] = useState<ProfileListItem|undefined>(undefined);
-    const [popUpAction, setPopUpAction] = useState<ModelPopUpAction>(ModelPopUpAction.EDIT);
+    const [popUpAction, setPopUpAction] = useState<ModelPopUpAction>(ModelPopUpAction.NONE);
     const SUPPORTED_POP_UP_ACTIONS:ModelPopUpAction[] = [ModelPopUpAction.EDIT, ModelPopUpAction.DELETE, ModelPopUpAction.NONE];
 
     const viewRoute: string = useMemo(() => (props.view === PARTNERSHIP_VIEW.FEWER_PARTNERSHIPS) ? 'fewer' 
@@ -69,10 +69,14 @@ const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
         let targetAction:ModelPopUpAction = popUpAction;
         
         //Match popUpAction in URL
-        targetAction = SUPPORTED_POP_UP_ACTIONS.includes(action?.toLowerCase() as ModelPopUpAction)
-            ? (action?.toLowerCase() as ModelPopUpAction)
-            : ModelPopUpAction.NONE;
-        targetPath = `/portal/partnership/${viewRoute}${targetAction.length > 0 ? `/${targetAction}` : ''}`;
+        if(action !== undefined) {
+            //DELETE is not supported, because we don't have a userID in the URL
+            const APPLICABLE_SUPPORTED_POP_UP_ACTIONS:ModelPopUpAction[] = SUPPORTED_POP_UP_ACTIONS.filter(p => p !== ModelPopUpAction.DELETE)
+            targetAction = APPLICABLE_SUPPORTED_POP_UP_ACTIONS.includes(action.toLowerCase() as ModelPopUpAction)
+                ? (action?.toLowerCase() as ModelPopUpAction)
+                : ModelPopUpAction.NONE;
+            targetPath = `/portal/partnership/${viewRoute}${targetAction.length > 0 ? `/${targetAction}` : ''}`;
+        }
 
         //Limit State Updates
         if(targetPath !== location.pathname) navigate(targetPath);
@@ -232,7 +236,7 @@ const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
                 />
             }
 
-            {/* Triggered to display by setting selectedPartner within page or popUpAction */}
+            {/* Accessible through '+' in Menu, in which case selectedUser and selectedPartner may be undefined */}
             {(viewState === PageState.VIEW) && (popUpAction === ModelPopUpAction.EDIT) &&
                 <PartnershipStatusADMIN
                     key={`Partnership-${selectedUser}-${selectedPartner}-ADMIN`}

--- a/src/12-Features/PartnershipPage.tsx
+++ b/src/12-Features/PartnershipPage.tsx
@@ -1,16 +1,16 @@
 import axios from 'axios';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { PartnerListItem, ProfileListItem, PartnerCountListItem, NewPartnerListItem } from '../0-Assets/field-sync/api-type-sync/profile-types';
 import { notify, processAJAXError, useAppSelector } from '../1-Utilities/hooks';
 import { PartnerItem } from '../2-Widgets/SearchList/SearchListItemCards';
-import { useNavigate } from 'react-router-dom';
 import { makeAbbreviatedText, makeDisplayText } from '../1-Utilities/utilities';
 import { PartnerStatusEnum } from '../0-Assets/field-sync/input-config-sync/profile-field-config';
 import { PartnershipDeleteAllADMIN, PartnershipStatusADMIN } from '../2-Widgets/PartnershipWidgets';
 import { SearchType, ListItemTypesEnum, DisplayItemType } from '../0-Assets/field-sync/input-config-sync/search-config';
 import SearchList from '../2-Widgets/SearchList/SearchList';
 import { SearchListKey, SearchListValue } from '../2-Widgets/SearchList/searchList-types';
-import { blueColor, PageState, ToastStyle } from '../100-App/app-types';
+import { blueColor, ModelPopUpAction, PageState, ToastStyle } from '../100-App/app-types';
 import FullImagePage from './Utility-Pages/FullImagePage';
 import { ImageDefaultEnum } from '../2-Widgets/ImageWidgets';
 
@@ -25,9 +25,11 @@ export enum PARTNERSHIP_VIEW {
 /* ADMIN ACCESS PAGE */
 const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
     const navigate = useNavigate();
+    const location = useLocation();
     const JWT:string = useAppSelector((state) => state.account.jwt);
     const userID:number = useAppSelector((state) => state.account.userID);
-
+    const { action } = useParams();
+    
     const [viewState, setViewState] = useState<PageState>(PageState.LOADING);
     const [defaultDisplayTitleList, setDefaultDisplayTitleList] = useState<string[]>(['Unassigned Users']);
     const [dualPartnerList, setDualPartnerList] = useState<[NewPartnerListItem, NewPartnerListItem][]>([]);
@@ -35,11 +37,50 @@ const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
     const [unassignedPartnerList, setUnassignedPartnerList] = useState<NewPartnerListItem[]>([]);
     const [availablePartnerList, setAvailablePartnerList] = useState<NewPartnerListItem[]>([]);
 
+    /* Select & Modify Partnership Status */
     const [selectedUser, setSelectedUser] = useState<ProfileListItem|undefined>(undefined); //undefined hides popup
     const [selectedPartner, setSelectedPartner] = useState<ProfileListItem|undefined>(undefined);
-    const [showDelete, setShowDelete] = useState<boolean>(false);
+    const [popUpAction, setPopUpAction] = useState<ModelPopUpAction>(ModelPopUpAction.EDIT);
+    const SUPPORTED_POP_UP_ACTIONS:ModelPopUpAction[] = [ModelPopUpAction.EDIT, ModelPopUpAction.DELETE, ModelPopUpAction.NONE];
 
+    const viewRoute: string = useMemo(() => (props.view === PARTNERSHIP_VIEW.FEWER_PARTNERSHIPS) ? 'fewer' 
+                                            : (props.view === PARTNERSHIP_VIEW.PENDING_PARTNERSHIPS) ? 'pending'
+                                            : 'recent', [props.view]);
+    
 
+    const updatePopUpAction = (newAction:ModelPopUpAction) => {
+        if(SUPPORTED_POP_UP_ACTIONS.includes(newAction) && popUpAction !== newAction) {
+            navigate(`/portal/partnership/${viewRoute}${newAction.length > 0 ? `/${newAction}` : ''}`, {replace: true});
+            setPopUpAction(newAction);
+
+            if(newAction === ModelPopUpAction.NONE) setSelectedPartner(undefined);
+        }
+    }
+
+    /* Trigger PopUp when partner is selected */
+    useEffect(() => { if(selectedUser !== undefined && selectedPartner !== undefined && popUpAction === ModelPopUpAction.NONE) 
+        updatePopUpAction(ModelPopUpAction.EDIT)}, [selectedPartner]);
+
+    /* Update state to reflect URL as source of truth */
+    useEffect(() => {
+        if(userID <= 0 || JWT.length === 0) return;
+
+        let targetPath:string = location.pathname;
+        let targetAction:ModelPopUpAction = popUpAction;
+        
+        //Match popUpAction in URL
+        targetAction = SUPPORTED_POP_UP_ACTIONS.includes(action?.toLowerCase() as ModelPopUpAction)
+            ? (action?.toLowerCase() as ModelPopUpAction)
+            : ModelPopUpAction.NONE;
+        targetPath = `/portal/partnership/${viewRoute}${targetAction.length > 0 ? `/${targetAction}` : ''}`;
+
+        //Limit State Updates
+        if(targetPath !== location.pathname) navigate(targetPath);
+        if(targetAction !== popUpAction) setPopUpAction(targetAction);
+
+    }, [JWT, location.pathname.includes('edit')]);
+
+    /* Fetch relevant data for props.view (Component gets reused) */
     useEffect(() => {
         if(JWT && props.view === PARTNERSHIP_VIEW.PENDING_PARTNERSHIPS) {
             axios.get(`${process.env.REACT_APP_DOMAIN}/api/admin/partnership/pending-list`, { headers:{ jwt:JWT } })
@@ -67,8 +108,9 @@ const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
 
     },[JWT, props.view]);
 
+    /* Fetch Available & Eligible Partners for selectedUser */
     useEffect(() => {
-        if(selectedUser && !showDelete && (props.view === PARTNERSHIP_VIEW.NEW_USERS || props.view === PARTNERSHIP_VIEW.FEWER_PARTNERSHIPS)) 
+        if(selectedUser && (popUpAction === ModelPopUpAction.NONE) && (props.view === PARTNERSHIP_VIEW.NEW_USERS || props.view === PARTNERSHIP_VIEW.FEWER_PARTNERSHIPS)) 
             axios.get(`${process.env.REACT_APP_DOMAIN}/api/admin/partnership/client/${selectedUser.userID}/available`, { headers: { jwt: JWT }})
                 .then((response:{ data:NewPartnerListItem[] }) => {
                     setAvailablePartnerList([...response.data]);
@@ -140,7 +182,7 @@ const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
                                 primaryButtonText='New Partner'
                                 onPrimaryButtonClick={() => setSelectedUser(partner)}
                                 alternativeButtonText='Clear Status'
-                                onAlternativeButtonClick={() => { setSelectedUser(partner); setShowDelete(true); }}
+                                onAlternativeButtonClick={() => { setSelectedUser(partner); updatePopUpAction(ModelPopUpAction.DELETE); }}
                             />
                             <p key={`status-${index}-max-partners`} className='status-count' >{partner.maxPartners || 0}</p>
                             {[...partner.partnerCountMap].map(([status, count]) => (
@@ -163,7 +205,7 @@ const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
                                     searchPrimaryButtonText: (selectedUser) ? 'Assign Partnership' : '', 
                                     onSearchPrimaryButtonCallback: (id:number, item:DisplayItemType) => setSelectedPartner(item as ProfileListItem),
                                     searchAlternativeButtonText: 'Remove',
-                                    onSearchAlternativeButtonCallback: (id:number, item:DisplayItemType) => { setSelectedUser(item as ProfileListItem); setShowDelete(true); }
+                                    onSearchAlternativeButtonCallback: (id:number, item:DisplayItemType) => { setSelectedUser(item as ProfileListItem); updatePopUpAction(ModelPopUpAction.DELETE); }
                                 }),
                                 [...unassignedPartnerList].map((partner:NewPartnerListItem) => new SearchListValue({displayType: ListItemTypesEnum.PARTNER, displayItem: partner, 
                                     onClick: (id:number) => navigate(`/portal/edit/profile/${id}`),
@@ -177,7 +219,7 @@ const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
                                     searchPrimaryButtonText: (selectedUser) ? 'Assign Partnership' : '', 
                                     onSearchPrimaryButtonCallback: (id:number, item:DisplayItemType) => setSelectedPartner(item as ProfileListItem),
                                     searchAlternativeButtonText: 'Remove',
-                                    onSearchAlternativeButtonCallback: (id:number, item:DisplayItemType) => { setSelectedUser(item as ProfileListItem); setShowDelete(true); }
+                                    onSearchAlternativeButtonCallback: (id:number, item:DisplayItemType) => { setSelectedUser(item as ProfileListItem); updatePopUpAction(ModelPopUpAction.DELETE); }
                                 }),
 
                                 [...availablePartnerList].map((partner:NewPartnerListItem) => new SearchListValue({displayType: ListItemTypesEnum.PARTNER, displayItem: partner, 
@@ -190,22 +232,23 @@ const PartnershipPage = (props:{view:PARTNERSHIP_VIEW}) => {
                 />
             }
 
-            {(viewState === PageState.VIEW) && (selectedUser !== undefined) && (selectedPartner !== undefined) &&
+            {/* Triggered to display by setting selectedPartner within page or popUpAction */}
+            {(viewState === PageState.VIEW) && (popUpAction === ModelPopUpAction.EDIT) &&
                 <PartnershipStatusADMIN
                     key={`Partnership-${selectedUser}-${selectedPartner}-ADMIN`}
-                    user={selectedUser}
-                    partner={selectedPartner}
-                    currentStatus={('status' in selectedUser) ? (selectedUser as PartnerListItem).status : PartnerStatusEnum.PENDING_CONTRACT_BOTH}
-                    onCancel={() => setSelectedPartner(undefined)}
+                    userID={selectedUser?.userID}
+                    partnerID={selectedPartner?.userID}
+                    currentStatus={(selectedUser && 'status' in selectedUser) ? (selectedUser as PartnerListItem).status : undefined}
+                    onCancel={() => updatePopUpAction(ModelPopUpAction.NONE)}
                 />
             }
 
-            {(viewState === PageState.VIEW) && showDelete && (selectedUser !== undefined) &&
+            {(viewState === PageState.VIEW) && (popUpAction === ModelPopUpAction.DELETE) && (selectedUser !== undefined) &&
                 <PartnershipDeleteAllADMIN
                     key={`Partnership-${selectedUser}-ADMIN`}
                     user={selectedUser}
                     statusMap={new Map(statusMap.filter(profile => profile.userID === selectedUser.userID)[0].partnerCountMap)}
-                    onCancel={() => setShowDelete(false)}
+                    onCancel={() => updatePopUpAction(ModelPopUpAction.NONE)}
                 />
             }
             

--- a/src/2-Widgets/Form/form.scss
+++ b/src/2-Widgets/Form/form.scss
@@ -470,19 +470,6 @@
         }
     }
 
-    #warning-box {
-        display: inline-block;
-        margin: 0.5rem 1.0rem;
-        background-color: goldenrod;
-        border-radius: $radius;
-
-        p {
-            margin: 0;
-            padding: 0.5rem;
-            white-space: wrap;
-        }
-    }
-
     .search-item {
         border: none;
     }

--- a/src/2-Widgets/Form/form.scss
+++ b/src/2-Widgets/Form/form.scss
@@ -462,11 +462,24 @@
 
         input {
             text-align: center;
-            max-width: 2.0rem;            
+            max-width: 4.0rem;            
         }     
         
         option {
             text-align: center;
+        }
+    }
+
+    #warning-box {
+        display: inline-block;
+        margin: 0.5rem 1.0rem;
+        background-color: goldenrod;
+        border-radius: $radius;
+
+        p {
+            margin: 0;
+            padding: 0.5rem;
+            white-space: wrap;
         }
     }
 

--- a/src/2-Widgets/PartnershipWidgets.tsx
+++ b/src/2-Widgets/PartnershipWidgets.tsx
@@ -96,12 +96,6 @@ export const PartnershipStatusADMIN = ({...props}:{key:string, userID?:number, p
                     <input type='number' value={partnerID} onChange={(event) => setPartnerID(parseInt(event.target.value))} />
                 </div>
 
-                {(partnerID <= userID) && 
-                    <span id='warning-box' >
-                        <p>&#9888; {'Database requires userID < partnerID, values will be auto swapped before assigning.'}</p>
-                    </span>
-                }
-
                 {<button className='submit-button' type='button' onClick={() => assignPartnership()}>Assign</button>}
                 <button className='submit-button alternative-button'  type='button' onClick={()=>props.onCancel()}>Cancel</button>
 

--- a/src/2-Widgets/PartnershipWidgets.tsx
+++ b/src/2-Widgets/PartnershipWidgets.tsx
@@ -4,7 +4,7 @@ import { PARTNERSHIP_CONTRACT, PartnerStatusEnum, RoleEnum } from '../0-Assets/f
 import { notify, processAJAXError, useAppDispatch, useAppSelector } from '../1-Utilities/hooks';
 import { ToastStyle } from '../100-App/app-types';
 import { makeDisplayText } from '../1-Utilities/utilities';
-import { PartnerListItem, ProfileListItem } from '../0-Assets/field-sync/api-type-sync/profile-types';
+import { PartnerListItem, ProfileListItem, ProfilePublicResponse } from '../0-Assets/field-sync/api-type-sync/profile-types';
 import { addPartner, addPartnerPendingPartner, removePartnerPendingUser } from '../100-App/redux-store';
 import { ProfileItem } from './SearchList/SearchListItemCards';
 
@@ -12,74 +12,102 @@ import { ProfileItem } from './SearchList/SearchListItemCards';
 /*****************************************************
  *  ADMIN | Partnership Status POP-UP PAGE COMPONENT *
  * ***************************************************/
-export const PartnershipStatusADMIN = ({...props}:{key:string, user:ProfileListItem, partner:ProfileListItem, currentStatus?:PartnerStatusEnum, onCancel:() => void}) => {
+export const PartnershipStatusADMIN = ({...props}:{key:string, userID?:number, partnerID?:number, currentStatus?:PartnerStatusEnum, onCancel:() => void}) => {
     const jwt:string = useAppSelector((state) => state.account.jwt);
-    const userRole:string = useAppSelector((state) => state.account.userProfile.userRole);
-    const [userID, setUserID] = useState<number>(props.user.userID);
-    const [partnerID, setPartnerID] = useState<number>(props.partner.userID);
-    const [status, setStatus] = useState<PartnerStatusEnum>(props.currentStatus || PartnerStatusEnum.PARTNER);
+    const jwtUserID:number = useAppSelector((state) => state.account.userID);
+    const jwtUserRole:RoleEnum = useAppSelector((state) => state.account.userRole);
 
-    /* Enforce UserID less than partnerID to match PartnerStatusEnum */
+    //At this point user/partner just refer to order they came in as props, props.currentStatus is in the perspective of props.userID 
+    const [userID, setUserID] = useState<number>(props.userID ?? jwtUserID ?? -1);
+    const [userProfile, setUserProfile] = useState<ProfileListItem|undefined>(undefined);
+    const [partnerID, setPartnerID] = useState<number>(props.partnerID ?? -1);
+    const [partnerProfile, setPartnerProfile] = useState<ProfileListItem|undefined>(undefined);
+    const [status, setStatus] = useState<PartnerStatusEnum>(props.currentStatus ?? PartnerStatusEnum.PENDING_CONTRACT_BOTH);
+
     useEffect(() => {
-        if(userRole !== RoleEnum.ADMIN)
+        if(jwtUserRole !== RoleEnum.ADMIN)
             notify('Admin restricted: partnership management', ToastStyle.ERROR, props.onCancel);
+    }, []);
 
-        else if(partnerID < userID) {
-            setUserID(partnerID);
-            setPartnerID(userID);
-            if(status === PartnerStatusEnum.PENDING_CONTRACT_USER)
-                setStatus(PartnerStatusEnum.PENDING_CONTRACT_PARTNER);
-            else if(status === PartnerStatusEnum.PENDING_CONTRACT_PARTNER)
-                setStatus(PartnerStatusEnum.PENDING_CONTRACT_USER);
-        }
-    }, [userID, partnerID]);
+    
+    const assignPartnership = () => {
+        const smallerUserID:number = Math.min(userID, partnerID);
+        const largerPartnerID:number = Math.max(userID, partnerID);
+        let newPartnerStatus:PartnerStatusEnum = status;
+
+        /* If partnerID < userID, swap before submitting */
+        if(partnerID < userID && newPartnerStatus === PartnerStatusEnum.PENDING_CONTRACT_USER)
+            newPartnerStatus = PartnerStatusEnum.PENDING_CONTRACT_PARTNER;
+        else if(partnerID < userID && status === PartnerStatusEnum.PENDING_CONTRACT_PARTNER)
+            newPartnerStatus = PartnerStatusEnum.PENDING_CONTRACT_USER;
+
+        axios.post(`${process.env.REACT_APP_DOMAIN}/api/admin/partnership/client/${smallerUserID}/partner/${largerPartnerID}/status/${newPartnerStatus}`, { }, { headers: { jwt }})
+            .then((response:{ data:string }) => {
+                notify(`${makeDisplayText(status)} Partnership Assigned`, ToastStyle.SUCCESS);
+                props.onCancel();
+            })
+            .catch((error) => processAJAXError(error, () => props.onCancel()));
+    }
+
+    /* Fetch Public Profiles to get Display Name and Profile Image */
+    useEffect(() => {
+        if(userID > 0)
+            axios.get(`${process.env.REACT_APP_DOMAIN}/api/user/${userID}/public`, { headers: { jwt }})
+                .then((response:{data:ProfilePublicResponse}) => setUserProfile(response.data)) //ProfilePublicResponse extends ProfileListItem
+                .catch((error) => processAJAXError(error));
+    }, [userID]);
+
+    useEffect(() => {
+        if(partnerID > 0)
+            axios.get(`${process.env.REACT_APP_DOMAIN}/api/user/${partnerID}/public`, { headers: { jwt }})
+                .then((response:{data:ProfilePublicResponse}) => setPartnerProfile(response.data))
+                .catch((error) => processAJAXError(error));
+    }, [partnerID]);
 
 
-    const assignPartnership = () => axios.post(`${process.env.REACT_APP_DOMAIN}/api/admin/partnership/client/${userID}/partner/${partnerID}/status/${status}`, { }, { headers: { jwt:jwt }})
-        .then((response:{ data:string }) => {
-            notify(`${makeDisplayText(status)} Partnership Assigned`, ToastStyle.SUCCESS);
-            props.onCancel();
-        })
-        .catch((error) => processAJAXError(error, () => props.onCancel()));
+    return (
+        <div key={'partnership-status-selector'+props.key} id='partnership-status' className='center-absolute-wrapper' onClick={()=>props.onCancel()} >
+            <div className='form-page-block center-absolute-inside' onClick={(e)=>e.stopPropagation()} >
+                <h1 className='name'>Update Partnership</h1>
 
+                <div className='matching-profile-box' >
+                    {(userProfile) &&
+                        <ProfileItem key={'profile-user'} user={userProfile} />
+                    }
 
-        return (
-            <div key={'partnership-status-selector'+props.key} id='partnership-status' className='center-absolute-wrapper' onClick={()=>props.onCancel()} >
-                <div className='form-page-block center-absolute-inside' onClick={(e)=>e.stopPropagation()} >
-                    <h1 className='name'>Update Partnership</h1>
-
-                    <div className='matching-profile-box' >
-                        {(userID === props.user.userID) ?
-                            <ProfileItem key={'profile-user'} user={props.user} /> : <div/>
-                        }
-
-                        {(partnerID === props.partner.userID) &&
-                            <ProfileItem key={'profile-partner'} user={props.partner} />
-                        }
-                    </div>
-
-                    <div className='update-partnership-inputs' >
-                        <label>User ID</label>
-                        <label>Status</label>
-                        <label>Partner ID</label>
-
-                        <input type='number' value={userID} onChange={(event) => setUserID(parseInt(event.target.value))} />
-                        <select value={status} onChange={(e) => setStatus(e.target.value as PartnerStatusEnum)}>
-                            {Object.values(PartnerStatusEnum).map(status => (
-                                <option key={status} value={status}>
-                                    {makeDisplayText(status)}
-                                </option>
-                            ))}
-                        </select>
-                        <input type='number' value={partnerID} onChange={(event) => setPartnerID(parseInt(event.target.value))} />
-                    </div>
-
-                    {<button className='submit-button' type='button' onClick={() => assignPartnership()}>Assign</button>}
-                    <button className='submit-button alternative-button'  type='button' onClick={()=>props.onCancel()}>Cancel</button>
-
+                    {(partnerProfile) &&
+                        <ProfileItem key={'profile-partner'} user={partnerProfile} />
+                    }
                 </div>
+
+                <div className='update-partnership-inputs' >
+                    <label>User ID</label>
+                    <label>Status</label>
+                    <label>Partner ID</label>
+
+                    <input type='number' value={userID} onChange={(event) => setUserID(parseInt(event.target.value))} />
+                    <select value={status} onChange={(e) => setStatus(e.target.value as PartnerStatusEnum)}>
+                        {Object.values(PartnerStatusEnum).map(status => (
+                            <option key={status} value={status}>
+                                {makeDisplayText(status)}
+                            </option>
+                        ))}
+                    </select>
+                    <input type='number' value={partnerID} onChange={(event) => setPartnerID(parseInt(event.target.value))} />
+                </div>
+
+                {(partnerID <= userID) && 
+                    <span id='warning-box' >
+                        <p>&#9888; {'Database requires userID < partnerID, values will be auto swapped before assigning.'}</p>
+                    </span>
+                }
+
+                {<button className='submit-button' type='button' onClick={() => assignPartnership()}>Assign</button>}
+                <button className='submit-button alternative-button'  type='button' onClick={()=>props.onCancel()}>Cancel</button>
+
             </div>
-        );
+        </div>
+    );
 }
 
 


### PR DESCRIPTION
# Refactor Partnerships Page
- Support for `ModelPopUpAction` which is the sub route for:
    - `/delete`  renders `PartnershipDeleteAllADMIN` which will clear partnership status by user & type
    - `/edit` renders `PartnershipStatusADMIN` which allows ADMIN to set status between two userIDs

- Refactored `PartnershipStatusADMIN`
    - Paramerters are optional, meaning can be initialized from `PartnershipPage` of blank from route
    - Fetching profiles to display Image & DisplayName
    - Expanded Input Fields
    - ***Removed Auto Re-ordering of userID's***
    - On Submit/Assign we are swapping order and status if required
    - Added Warning Message Below

![image](https://github.com/user-attachments/assets/3b5bc894-a641-459c-ae79-e5efa9258598)
